### PR TITLE
Feature/inject non registered types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] - 2024-07-11
+## v0.3.0 - 2024-07-12
 
 ### Added
 
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Service registry accepts object instances as singleton service registrations
 * Adds the `ResolveRequiredService[T]` convenience function that resolves and safe-casts objects
 * Registers resolver instance with the registry so that the `Resolver` object can be injected into factory and constructor methods
+* The resolver can now accept instances of non-registered types via the `ResolveWithOptions[T]` method
+* `ServiceRegistry` has new methods for creating linked and scoped registry objects (which share the same `ServiceIdSequence`). Scoped registries inherit all parent service registrations, while linked registries are empty. See `CreateLinkedRegistry` and `CreateScope` methods.
+  
+### Changed
+
+* A `ServiceRegistryAccessor` is no longer a `ServiceRegisty`, it is the other way around
+* The creation of service registrations and type activators has been refactored; see `activator.go` and `service_registration.go` modules
+* Multiple registries can be grouped with `NewMultiRegistryAccessor` to simplify the lookup of service registrations from linked registries. The resolver uses this accessor type to merge registered service types with object instances for unregistered types.
+* 
 
 ## v0.2.0 - 2024-07-11
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This dependency injection package may become your favorite ingredient for your G
 - ✔️ Resolve objects on-demand
   - ✔️ Allow consumption of `Resolver` in favor of custom factories
   - ⏳ Validate registered services; fail early during application startup if missing registrations are encountered
-  - ⏳ Provide parameters for non-registered types and data
+  - ✔️ Provide instances for non-registered types, use `ResolveWithOptions[T]` insted of `Resolve[T]`
 - ⏳ Support multiple service registrations for the same interface
   - ⏳ Register named services (mutiple services), resolve via `func(key string) any`
   - ⏳ Resolve list of service

--- a/pkg/activator.go
+++ b/pkg/activator.go
@@ -1,0 +1,21 @@
+package pkg
+
+import (
+	"github.com/matzefriedrich/parsley/internal"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"reflect"
+)
+
+func CreateServiceActivatorFrom[T any](instance T) (func() T, error) {
+	if internal.IsNil(instance) {
+		return nil, types.NewRegistryError(types.ErrorInstanceCannotBeNil)
+	}
+	t := reflect.TypeOf((*T)(nil)).Elem()
+	if t.Kind() != reflect.Interface {
+		return nil, types.NewRegistryError(types.ErrorActivatorFunctionsMustReturnAnInterface)
+	}
+	instanceFunc := func() T {
+		return instance
+	}
+	return instanceFunc, nil
+}

--- a/pkg/registry_accessor.go
+++ b/pkg/registry_accessor.go
@@ -1,0 +1,30 @@
+package pkg
+
+import (
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"reflect"
+)
+
+type multiRegistryAccessor struct {
+	registries []types.ServiceRegistryAccessor
+}
+
+func (m *multiRegistryAccessor) TryGetServiceRegistration(serviceType reflect.Type) (types.ServiceRegistration, bool) {
+	for _, registry := range m.registries {
+		registration, ok := registry.TryGetServiceRegistration(serviceType)
+		if ok {
+			return registration, ok
+		}
+	}
+	return nil, false
+}
+
+var _ types.ServiceRegistryAccessor = &multiRegistryAccessor{}
+
+func NewMultiRegistryAccessor(registries ...types.ServiceRegistryAccessor) types.ServiceRegistryAccessor {
+	serviceRegistries := make([]types.ServiceRegistryAccessor, 0)
+	serviceRegistries = append(serviceRegistries, registries...)
+	return &multiRegistryAccessor{
+		registries: serviceRegistries,
+	}
+}

--- a/pkg/resolver_options.go
+++ b/pkg/resolver_options.go
@@ -1,0 +1,25 @@
+package pkg
+
+import (
+	"github.com/matzefriedrich/parsley/pkg/types"
+)
+
+func applyResolverOptions(registry types.ServiceRegistry, options ...types.ResolverOptionsFunc) error {
+	for _, option := range options {
+		err := option(registry)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func WithInstance[T any](instance T) types.ResolverOptionsFunc {
+	return func(registry types.ServiceRegistry) error {
+		err := RegisterInstance[T](registry, instance)
+		if err != nil {
+			return types.NewRegistryError("cannot register type with resolver options", types.WithCause(err))
+		}
+		return nil
+	}
+}

--- a/pkg/resolver_options.go
+++ b/pkg/resolver_options.go
@@ -18,7 +18,7 @@ func WithInstance[T any](instance T) types.ResolverOptionsFunc {
 	return func(registry types.ServiceRegistry) error {
 		err := RegisterInstance[T](registry, instance)
 		if err != nil {
-			return types.NewRegistryError("cannot register type with resolver options", types.WithCause(err))
+			return types.NewRegistryError(types.ErrorCannotRegisterTypeWithResolverOptions, types.WithCause(err))
 		}
 		return nil
 	}

--- a/pkg/resolver_options_test.go
+++ b/pkg/resolver_options_test.go
@@ -1,0 +1,28 @@
+package pkg
+
+import (
+	"context"
+	"github.com/matzefriedrich/parsley/internal"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Resolver_ResolveWithOptions_inject_unregistered_service_instance(t *testing.T) {
+
+	// Arrange
+	sut := NewServiceRegistry()
+
+	// Act
+	_ = RegisterScoped(sut, NewFooConsumer)
+
+	// Assert
+	r := sut.BuildResolver()
+	parsleyContext := internal.NewScopedContext(context.Background())
+	consumer1, _ := r.ResolveWithOptions(parsleyContext, types.ServiceType[FooConsumer](), WithInstance[Foo](NewFoo()))
+	assert.NotNil(t, consumer1)
+
+	actual, ok := consumer1.(FooConsumer)
+	assert.True(t, ok)
+	assert.NotNil(t, actual)
+}

--- a/pkg/types/resolver_error.go
+++ b/pkg/types/resolver_error.go
@@ -11,6 +11,7 @@ const (
 	ErrorCannotBuildDependencyGraph              = "failed to build dependency graph"
 	ErrorInstanceCannotBeNil                     = "instance cannot be nil"
 	ErrorServiceTypeMustBeInterface              = "service type must be an interface"
+	ErrorCannotRegisterTypeWithResolverOptions   = "cannot register type with resolver options"
 )
 
 var (
@@ -20,6 +21,7 @@ var (
 	ErrCircularDependencyDetected              = errors.New(ErrorCircularDependencyDetected)
 	ErrInstanceCannotBeNil                     = errors.New(ErrorInstanceCannotBeNil)
 	ErrServiceTypeMustBeInterface              = errors.New(ErrorServiceTypeMustBeInterface)
+	ErrCannotRegisterTypeWithResolverOptions   = errors.New(ErrorCannotRegisterTypeWithResolverOptions)
 )
 
 type ResolverError struct {

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -12,7 +12,10 @@ type FunctionInfo interface {
 }
 
 type ServiceRegistry interface {
+	ServiceRegistryAccessor
 	BuildResolver() Resolver
+	CreateLinkedRegistry() ServiceRegistry
+	CreateScope() ServiceRegistry
 	IsRegistered(serviceType reflect.Type) bool
 	Register(activatorFunc any, scope LifetimeScope) error
 	RegisterModule(modules ...ModuleFunc) error
@@ -21,7 +24,6 @@ type ServiceRegistry interface {
 type ModuleFunc func(registry ServiceRegistry) error
 
 type ServiceRegistryAccessor interface {
-	ServiceRegistry
 	TryGetServiceRegistration(serviceType reflect.Type) (ServiceRegistration, bool)
 }
 
@@ -33,10 +35,18 @@ type ServiceRegistration interface {
 	LifetimeScope() LifetimeScope
 }
 
+type ServiceRegistrationSetup interface {
+	ServiceRegistration
+	SetId(id uint64) error
+}
+
 type RegistrationConfigurationFunc func(r ServiceRegistration)
+
+type ResolverOptionsFunc func(registry ServiceRegistry) error
 
 type Resolver interface {
 	Resolve(ctx context.Context, serviceType reflect.Type) (interface{}, error)
+	ResolveWithOptions(ctx context.Context, serviceType reflect.Type, options ...ResolverOptionsFunc) (interface{}, error)
 }
 
 type DependencyInfo interface {


### PR DESCRIPTION
- The resolver can now accept instances of non-registered types via the `ResolveWithOptions[T]` method.
- Contains a few more refactorings to support extension of the resolver
- Adds tests