### PR TITLE
Feature/multiple services for interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## v0.5.0 - 2024-07-16
+
+### Added
+
+* The service registry now accepts multiple registrations for the same interface (changes internal data structures to keep track of registrations; see `ServiceRegistrationList`).
+* Adds the `ResolveRequiredServices[T]` convenience function to resolve all service instances; `ResolveRequiredService[T]` can resolve a single service but will return an error if service registrations are ambiguous.
+
+### Changed
+
+* Extends the resolver to handle multiple service registrations per interface type. The resolver returns resolved objects as a list. 
+
+
 ## v0.4.0 - 2024-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Though dependency injection is less prevalent in Golang (compared to other langu
   - ✔️ Register factory functions to create instances of services based on input parameters provided at runtime
   - ⏳ Validate registered services; fail early during application startup if missing registrations are encountered
   - ✔️ Provide instances for non-registered types, use `ResolveWithOptions[T]` insted of `Resolve[T]`
-- ⏳ Support multiple service registrations for the same interface
+- ✔️ Support multiple service registrations for the same interface
   - ⏳ Register named services (mutiple services), resolve via `func(key string) any`
-  - ⏳ Resolve list of service
+  - ✔️ Resolve services as list (default)
 - ⏳ Support sub-scopes
   - ⏳ Automatic clean-up
 

--- a/internal/tests/registry_register_multiple_types_test.go
+++ b/internal/tests/registry_register_multiple_types_test.go
@@ -1,0 +1,191 @@
+package tests
+
+import (
+	"context"
+	"errors"
+	"github.com/matzefriedrich/parsley/internal/core"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func Test_Registry_register_multiple_transient_types(t *testing.T) {
+
+	// Arrange
+	sut := registration.NewServiceRegistry()
+
+	// Act
+	_ = registration.RegisterTransient(sut, newFoo3)
+	registerErr := registration.RegisterTransient(sut, newFoo4)
+	if errors.Is(registerErr, types.ErrTypeAlreadyRegistered) {
+		assert.FailNow(t, "type is already registered")
+	}
+
+	r := resolving.NewResolver(sut)
+
+	// Assert
+	resolvedServices, err := resolving.ResolveRequiredServices[multiFoo](r, context.Background())
+
+	assert.NoError(t, err)
+	assert.Len(t, resolvedServices, 2)
+
+	var foo3Instance, foo4Instance multiFoo
+	for _, service := range resolvedServices {
+		switch service.(type) {
+		case *foo3:
+			foo3Instance = service.(*foo3)
+		case *foo4:
+			foo4Instance = service.(*foo4)
+		}
+	}
+
+	assert.NotNil(t, foo3Instance)
+	assert.Equal(t, "foo3", foo3Instance.Bar())
+
+	assert.NotNil(t, foo4Instance)
+	assert.Equal(t, "foo4", foo4Instance.Bar())
+}
+
+func Test_Registry_register_multiple_types_mixed_lifetime_scopes(t *testing.T) {
+
+	// Arrange
+	sut := registration.NewServiceRegistry()
+
+	// Act
+	_ = registration.RegisterTransient(sut, newFoo3)
+	registerErr := registration.RegisterSingleton(sut, newFoo4)
+	if errors.Is(registerErr, types.ErrTypeAlreadyRegistered) {
+		assert.FailNow(t, "type is already registered")
+	}
+
+	r := resolving.NewResolver(sut)
+	resolvedServices1, err := resolving.ResolveRequiredServices[multiFoo](r, context.Background())
+	resolvedServices2, _ := resolving.ResolveRequiredServices[multiFoo](r, context.Background())
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, resolvedServices1, 2)
+
+	var foo3Instance1, foo4Instance1 multiFoo
+	for _, service := range resolvedServices1 {
+		switch service.(type) {
+		case *foo3:
+			foo3Instance1 = service.(*foo3)
+		case *foo4:
+			foo4Instance1 = service.(*foo4)
+		}
+	}
+
+	assert.NotNil(t, foo3Instance1)
+	assert.Equal(t, "foo3", foo3Instance1.Bar())
+
+	assert.NotNil(t, foo4Instance1)
+	assert.Equal(t, "foo4", foo4Instance1.Bar())
+
+	var foo3Instance2, foo4Instance2 multiFoo
+	for _, service := range resolvedServices2 {
+		switch service.(type) {
+		case *foo3:
+			foo3Instance2 = service.(*foo3)
+		case *foo4:
+			foo4Instance2 = service.(*foo4)
+		}
+	}
+
+	assert.NotNil(t, foo3Instance2)
+	assert.NotEqual(t, reflect.ValueOf(foo3Instance1).Pointer(), reflect.ValueOf(foo3Instance2).Pointer())
+
+	assert.NotNil(t, foo4Instance2)
+	assert.Equal(t, reflect.ValueOf(foo4Instance1).Pointer(), reflect.ValueOf(foo4Instance2).Pointer())
+}
+
+func Test_Registry_register_multiple_types_mixed_lifetime_scopes_2(t *testing.T) {
+
+	// Arrange
+	sut := registration.NewServiceRegistry()
+
+	// Act
+	_ = registration.RegisterTransient(sut, newFoo3)
+	registerErr := registration.RegisterScoped(sut, newFoo4)
+	if errors.Is(registerErr, types.ErrTypeAlreadyRegistered) {
+		assert.FailNow(t, "type is already registered")
+	}
+
+	r := resolving.NewResolver(sut)
+	scope := core.NewScopedContext(context.Background())
+	resolvedServices1, err := resolving.ResolveRequiredServices[multiFoo](r, scope)
+	resolvedServices2, _ := resolving.ResolveRequiredServices[multiFoo](r, scope)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, resolvedServices1, 2)
+
+	var foo3Instance1, foo4Instance1 multiFoo
+	for _, service := range resolvedServices1 {
+		switch service.(type) {
+		case *foo3:
+			foo3Instance1 = service.(*foo3)
+		case *foo4:
+			foo4Instance1 = service.(*foo4)
+		}
+	}
+
+	assert.NotNil(t, foo3Instance1)
+	assert.Equal(t, "foo3", foo3Instance1.Bar())
+
+	assert.NotNil(t, foo4Instance1)
+	assert.Equal(t, "foo4", foo4Instance1.Bar())
+
+	var foo3Instance2, foo4Instance2 multiFoo
+	for _, service := range resolvedServices2 {
+		switch service.(type) {
+		case *foo3:
+			foo3Instance2 = service.(*foo3)
+		case *foo4:
+			foo4Instance2 = service.(*foo4)
+		}
+	}
+
+	assert.NotNil(t, foo3Instance2)
+	assert.NotEqual(t, reflect.ValueOf(foo3Instance1).Pointer(), reflect.ValueOf(foo3Instance2).Pointer())
+
+	assert.NotNil(t, foo4Instance2)
+	assert.Equal(t, reflect.ValueOf(foo4Instance1).Pointer(), reflect.ValueOf(foo4Instance2).Pointer())
+}
+
+type multiFoo interface {
+	Bar() string
+}
+
+type foo3 struct {
+	name string
+}
+
+func newFoo3() multiFoo {
+	return &foo3{
+		name: "foo3",
+	}
+}
+
+func (f foo3) Bar() string {
+	return f.name
+}
+
+type foo4 struct {
+	name string
+}
+
+func newFoo4() multiFoo {
+	return &foo4{
+		name: "foo4",
+	}
+}
+func (f foo4) Bar() string {
+	return f.name
+}
+
+var _ multiFoo = &foo3{}
+var _ multiFoo = &foo4{}

--- a/internal/tests/registry_test.go
+++ b/internal/tests/registry_test.go
@@ -43,7 +43,7 @@ func Test_Registry_NewResolver_resolve_type_with_dependencies(t *testing.T) {
 	// Assert
 	r := resolving.NewResolver(sut)
 	parsleyContext := core.NewScopedContext(context.Background())
-	resolved, _ := r.Resolve(parsleyContext, registration.ServiceType[FooConsumer]())
+	resolved, _ := resolving.ResolveRequiredService[FooConsumer](r, parsleyContext)
 	assert.NotNil(t, resolved)
 
 	actual, ok := resolved.(FooConsumer)
@@ -63,10 +63,10 @@ func Test_Registry_NewResolver_resolve_scoped_from_same_context_must_be_return_s
 	// Assert
 	r := resolving.NewResolver(sut)
 	parsleyContext := core.NewScopedContext(context.Background())
-	consumer1, _ := r.Resolve(parsleyContext, registration.ServiceType[FooConsumer]())
+	consumer1, _ := resolving.ResolveRequiredService[FooConsumer](r, parsleyContext)
 	assert.NotNil(t, consumer1)
 
-	consumer2, _ := r.Resolve(parsleyContext, registration.ServiceType[FooConsumer]())
+	consumer2, _ := resolving.ResolveRequiredService[FooConsumer](r, parsleyContext)
 	assert.NotNil(t, consumer2)
 
 	actual, ok := consumer1.(FooConsumer)
@@ -88,11 +88,12 @@ func Test_Registry_NewResolver_resolve_scoped_from_different_context_must_be_ret
 	r := resolving.NewResolver(sut)
 
 	parsleyContext1 := core.NewScopedContext(context.Background())
-	consumer1, _ := r.Resolve(parsleyContext1, registration.ServiceType[FooConsumer]())
+	consumer1, _ := resolving.ResolveRequiredService[FooConsumer](r, parsleyContext1)
+
 	assert.NotNil(t, consumer1)
 
 	parsleyContext2 := core.NewScopedContext(context.Background())
-	consumer2, _ := r.Resolve(parsleyContext2, registration.ServiceType[FooConsumer]())
+	consumer2, _ := resolving.ResolveRequiredService[FooConsumer](r, parsleyContext2)
 	assert.NotNil(t, consumer2)
 
 	actual, ok := consumer1.(FooConsumer)
@@ -140,7 +141,7 @@ func Test_Registry_RegisterInstance_registers_singleton_service_from_object(t *t
 	// Arrange
 	assert.True(t, fooRegistered)
 
-	resolved, _ := r.Resolve(context.Background(), registration.ServiceType[Foo]())
+	resolved, _ := resolving.ResolveRequiredService[Foo](r, context.Background())
 	assert.NotNil(t, resolved)
 
 	actual, ok := resolved.(Foo)

--- a/internal/tests/resolver_options_test.go
+++ b/internal/tests/resolver_options_test.go
@@ -21,7 +21,10 @@ func Test_Resolver_ResolveWithOptions_inject_unregistered_service_instance(t *te
 	r := resolving.NewResolver(sut)
 
 	parsleyContext := core.NewScopedContext(context.Background())
-	consumer1, _ := r.ResolveWithOptions(parsleyContext, registration.ServiceType[FooConsumer](), resolving.WithInstance[Foo](NewFoo()))
+	consumers, _ := r.ResolveWithOptions(parsleyContext, registration.ServiceType[FooConsumer](), resolving.WithInstance[Foo](NewFoo()))
+	assert.Equal(t, 1, len(consumers))
+
+	consumer1 := consumers[0]
 	assert.NotNil(t, consumer1)
 
 	actual, ok := consumer1.(FooConsumer)

--- a/pkg/registration/registry_accessor.go
+++ b/pkg/registration/registry_accessor.go
@@ -9,9 +9,19 @@ type multiRegistryAccessor struct {
 	registries []types.ServiceRegistryAccessor
 }
 
-func (m *multiRegistryAccessor) TryGetServiceRegistration(serviceType reflect.Type) (types.ServiceRegistration, bool) {
+func (m *multiRegistryAccessor) TryGetSingleServiceRegistration(serviceType reflect.Type) (types.ServiceRegistration, bool) {
 	for _, registry := range m.registries {
-		registration, ok := registry.TryGetServiceRegistration(serviceType)
+		registration, ok := registry.TryGetSingleServiceRegistration(serviceType)
+		if ok {
+			return registration, ok
+		}
+	}
+	return nil, false
+}
+
+func (m *multiRegistryAccessor) TryGetServiceRegistrations(serviceType reflect.Type) (types.ServiceRegistrationList, bool) {
+	for _, registry := range m.registries {
+		registration, ok := registry.TryGetServiceRegistrations(serviceType)
 		if ok {
 			return registration, ok
 		}

--- a/pkg/registration/service_registration.go
+++ b/pkg/registration/service_registration.go
@@ -57,6 +57,11 @@ func (s *serviceRegistration) SetId(id uint64) error {
 	return nil
 }
 
+func (s *serviceRegistration) IsSame(other types.ServiceRegistration) bool {
+	sr, ok := other.(*serviceRegistration)
+	return ok && s.activatorFunc.Pointer() == sr.activatorFunc.Pointer()
+}
+
 func (s *serviceRegistration) LifetimeScope() types.LifetimeScope {
 	return s.lifetimeScope
 }

--- a/pkg/registration/service_registration_list.go
+++ b/pkg/registration/service_registration_list.go
@@ -1,0 +1,61 @@
+package registration
+
+import (
+	"github.com/matzefriedrich/parsley/internal/core"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"sync"
+)
+
+type serviceRegistrationList struct {
+	id               uint64
+	identifierSource core.ServiceIdSequence
+	registrations    []types.ServiceRegistration
+	m                sync.RWMutex
+}
+
+func (s *serviceRegistrationList) IsEmpty() bool {
+	return len(s.registrations) == 0
+}
+
+func (s *serviceRegistrationList) Registrations() []types.ServiceRegistration {
+	s.m.RLock()
+	defer s.m.RUnlock()
+	return s.registrations
+}
+
+func (s *serviceRegistrationList) AddRegistration(registration types.ServiceRegistrationSetup) error {
+
+	s.m.Lock()
+	defer s.m.Unlock()
+
+	for _, reg := range s.registrations {
+		if reg.IsSame(registration) {
+			return types.NewRegistryError(types.ErrorTypeAlreadyRegistered)
+		}
+	}
+
+	registrationId := s.identifierSource.Next()
+	err := registration.SetId(registrationId)
+	if err != nil {
+		return types.NewRegistryError(types.ErrorServiceAlreadyLinkedWithAnotherList, types.WithCause(err))
+	}
+
+	s.registrations = append(s.registrations, registration)
+	return nil
+}
+
+func (s *serviceRegistrationList) Id() uint64 {
+	return s.id
+}
+
+var _ types.ServiceRegistrationList = &serviceRegistrationList{}
+
+func NewServiceRegistrationList(sequence core.ServiceIdSequence) types.ServiceRegistrationList {
+	id := sequence.Next()
+	return &serviceRegistrationList{
+		id:               id,
+		identifierSource: sequence,
+		registrations:    make([]types.ServiceRegistration, 0),
+		m:                sync.RWMutex{},
+	}
+}

--- a/pkg/types/registry_error.go
+++ b/pkg/types/registry_error.go
@@ -3,13 +3,16 @@ package types
 import "errors"
 
 const (
-	ErrorRequiresFunctionValue = "the given value is not function"
-	ErrorCannotRegisterModule  = "failed to register module"
+	ErrorRequiresFunctionValue               = "the given value is not function"
+	ErrorCannotRegisterModule                = "failed to register module"
+	ErrorTypeAlreadyRegistered               = "type already registered"
+	ErrorServiceAlreadyLinkedWithAnotherList = "service already linked with another list"
 )
 
 var (
 	ErrRequiresFunctionValue = errors.New(ErrorRequiresFunctionValue)
 	ErrCannotRegisterModule  = errors.New(ErrorCannotRegisterModule)
+	ErrTypeAlreadyRegistered = errors.New(ErrorTypeAlreadyRegistered)
 )
 
 type registryError struct {

--- a/pkg/types/resolver_error.go
+++ b/pkg/types/resolver_error.go
@@ -6,6 +6,7 @@ const (
 	ErrorServiceTypeNotRegistered              = "service type is not registered"
 	ErrorRequiredServiceNotRegistered          = "required service type is not registered"
 	ErrorCannotResolveService                  = "cannot resolve service"
+	ErrorAmbiguousServiceInstancesResolved     = "the resolve operation resulted in multiple service instances"
 	ErrorActivatorFunctionInvalidReturnType    = "activator function has an invalid return type"
 	ErrorCircularDependencyDetected            = "circular dependency detected"
 	ErrorCannotBuildDependencyGraph            = "failed to build dependency graph"

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -23,15 +23,24 @@ type ServiceRegistry interface {
 type ModuleFunc func(registry ServiceRegistry) error
 
 type ServiceRegistryAccessor interface {
-	TryGetServiceRegistration(serviceType reflect.Type) (ServiceRegistration, bool)
+	TryGetServiceRegistrations(serviceType reflect.Type) (ServiceRegistrationList, bool)
+	TryGetSingleServiceRegistration(serviceType reflect.Type) (ServiceRegistration, bool)
 }
 
 type ServiceRegistration interface {
 	Id() uint64
 	InvokeActivator(params ...interface{}) (interface{}, error)
+	IsSame(other ServiceRegistration) bool
+	LifetimeScope() LifetimeScope
 	RequiredServiceTypes() []reflect.Type
 	ServiceType() reflect.Type
-	LifetimeScope() LifetimeScope
+}
+
+type ServiceRegistrationList interface {
+	AddRegistration(registration ServiceRegistrationSetup) error
+	Id() uint64
+	Registrations() []ServiceRegistration
+	IsEmpty() bool
 }
 
 type ServiceRegistrationSetup interface {
@@ -44,8 +53,8 @@ type RegistrationConfigurationFunc func(r ServiceRegistration)
 type ResolverOptionsFunc func(registry ServiceRegistry) error
 
 type Resolver interface {
-	Resolve(ctx context.Context, serviceType reflect.Type) (interface{}, error)
-	ResolveWithOptions(ctx context.Context, serviceType reflect.Type, options ...ResolverOptionsFunc) (interface{}, error)
+	Resolve(ctx context.Context, serviceType reflect.Type) ([]interface{}, error)
+	ResolveWithOptions(ctx context.Context, serviceType reflect.Type, options ...ResolverOptionsFunc) ([]interface{}, error)
 }
 
 type DependencyInfo interface {


### PR DESCRIPTION
- The service registry does now accept multiple registrations for the same interface (changes internal data structures to keep track of registrations)
- Adds new convenience functions to resolve service(s)
- Extends the resolver to handle multiple service registrations per interface type