### PR TITLE
Feature/support non interface types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added 
 
 * Adds the `Activate[T]` method which can resolve an instance from an unregistered activator func
+* Allows registration and activation of pointer types
+
+### Changes
+
+* Renames the `ServiceType[T]` method to `MakeServiceType[T]`; adds service type representing the reflected type and typename
+* Replaces all usages of `reflect.Type` by `ServiceType` in all Parsley interfaces
 
 
 ## v0.5.0 - 2024-07-16

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Though dependency injection is less prevalent in Golang (compared to other langu
 ## Features
 
 - ✔️ Register types via constructor functions
-- ✔️ Resolve objects by interface
+- ✔️ Resolve objects by type (both interface and pointer type)
   - ✔️ Constructor injection
   - ⏳ Injection via field initialization (requires annotation)
   - ❌ Injection via setter methods

--- a/internal/tests/registry_register_instance_test.go
+++ b/internal/tests/registry_register_instance_test.go
@@ -17,7 +17,6 @@ func Test_Registry_RegisterInstance_accepts_pointer(t *testing.T) {
 
 	// Act
 	err := registration.RegisterInstance(registry, options)
-
 	resolver := resolving.NewResolver(registry)
 	actual, _ := resolving.ResolveRequiredService[*someOptions](resolver, resolving.NewScopedContext(context.Background()))
 
@@ -27,10 +26,38 @@ func Test_Registry_RegisterInstance_accepts_pointer(t *testing.T) {
 	assert.Equal(t, options.value, actual.value)
 }
 
+func Test_Registry_RegisterInstance_resolve_object_with_pointer_dependency(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+
+	options := NewOptions("value")
+	_ = registration.RegisterInstance(registry, options)
+	_ = registration.RegisterTransient(registry, NewOptionsConsumer)
+
+	resolver := resolving.NewResolver(registry)
+
+	// Act
+	actual, _ := resolving.ResolveRequiredService[*optionsConsumer](resolver, resolving.NewScopedContext(context.Background()))
+
+	// Assert
+	assert.NotNil(t, actual)
+}
+
 type someOptions struct {
 	value string
 }
 
 func NewOptions(value string) *someOptions {
 	return &someOptions{value}
+}
+
+type optionsConsumer struct {
+	options *someOptions
+}
+
+func NewOptionsConsumer(options *someOptions) *optionsConsumer {
+	return &optionsConsumer{
+		options: options,
+	}
 }

--- a/internal/tests/registry_register_instance_test.go
+++ b/internal/tests/registry_register_instance_test.go
@@ -1,0 +1,36 @@
+package tests
+
+import (
+	"context"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Registry_RegisterInstance_accepts_pointer(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+
+	options := NewOptions("value")
+
+	// Act
+	err := registration.RegisterInstance(registry, options)
+
+	resolver := resolving.NewResolver(registry)
+	actual, _ := resolving.ResolveRequiredService[*someOptions](resolver, resolving.NewScopedContext(context.Background()))
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, options.value, actual.value)
+}
+
+type someOptions struct {
+	value string
+}
+
+func NewOptions(value string) *someOptions {
+	return &someOptions{value}
+}

--- a/internal/tests/registry_test.go
+++ b/internal/tests/registry_test.go
@@ -22,8 +22,8 @@ func Test_ServiceRegistry_register_types_with_different_lifetime_behavior(t *tes
 	_ = registration.RegisterSingleton(sut, NewFoo)
 	_ = registration.RegisterTransient(sut, NewFooConsumer)
 
-	fooRegistered := sut.IsRegistered(registration.ServiceType[Foo]())
-	fooConsumerRegistered := sut.IsRegistered(registration.ServiceType[FooConsumer]())
+	fooRegistered := sut.IsRegistered(types.MakeServiceType[Foo]())
+	fooConsumerRegistered := sut.IsRegistered(types.MakeServiceType[FooConsumer]())
 
 	// Assert
 	assert.True(t, fooRegistered)
@@ -115,8 +115,8 @@ func Test_Registry_RegisterModule_registers_collection_of_services(t *testing.T)
 
 	_ = sut.RegisterModule(fooModule)
 
-	fooRegistered := sut.IsRegistered(registration.ServiceType[Foo]())
-	fooConsumerRegistered := sut.IsRegistered(registration.ServiceType[FooConsumer]())
+	fooRegistered := sut.IsRegistered(types.MakeServiceType[Foo]())
+	fooConsumerRegistered := sut.IsRegistered(types.MakeServiceType[FooConsumer]())
 
 	// Assert
 	assert.True(t, fooRegistered)
@@ -133,7 +133,7 @@ func Test_Registry_RegisterInstance_registers_singleton_service_from_object(t *t
 	// Act
 	_ = registration.RegisterInstance(sut, instance)
 
-	fooRegistered := sut.IsRegistered(registration.ServiceType[Foo]())
+	fooRegistered := sut.IsRegistered(types.MakeServiceType[Foo]())
 
 	r := resolving.NewResolver(sut)
 

--- a/internal/tests/resolver_options_test.go
+++ b/internal/tests/resolver_options_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"github.com/matzefriedrich/parsley/pkg/registration"
 	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -20,7 +21,7 @@ func Test_Resolver_ResolveWithOptions_inject_unregistered_service_instance(t *te
 	r := resolving.NewResolver(sut)
 
 	parsleyContext := resolving.NewScopedContext(context.Background())
-	consumers, _ := r.ResolveWithOptions(parsleyContext, registration.ServiceType[FooConsumer](), resolving.WithInstance[Foo](NewFoo()))
+	consumers, _ := r.ResolveWithOptions(parsleyContext, types.MakeServiceType[FooConsumer](), resolving.WithInstance[Foo](NewFoo()))
 	assert.Equal(t, 1, len(consumers))
 
 	consumer1 := consumers[0]

--- a/internal/tests/resolver_test.go
+++ b/internal/tests/resolver_test.go
@@ -21,7 +21,7 @@ func Test_Resolver_Resolve_returns_err_if_circular_dependency_detected(t *testin
 	scope := resolving.NewScopedContext(context.Background())
 
 	// Act
-	_, err := r.Resolve(scope, registration.ServiceType[fooBar]())
+	_, err := r.Resolve(scope, types.MakeServiceType[fooBar]())
 
 	// Assert
 	assert.ErrorIs(t, err, types.ErrCircularDependencyDetected)

--- a/pkg/registration/activator.go
+++ b/pkg/registration/activator.go
@@ -14,6 +14,7 @@ func CreateServiceActivatorFrom[T any](instance T) (func() T, error) {
 	switch t.Kind() {
 	case reflect.Func:
 	case reflect.Interface:
+	case reflect.Pointer:
 	default:
 		return nil, types.NewRegistryError(types.ErrorActivatorFunctionInvalidReturnType)
 	}

--- a/pkg/registration/dependency.go
+++ b/pkg/registration/dependency.go
@@ -2,7 +2,6 @@ package registration
 
 import (
 	"github.com/matzefriedrich/parsley/pkg/types"
-	"reflect"
 	"sync"
 )
 
@@ -40,7 +39,7 @@ func (d *dependencyInfo) AddRequiredServiceInfo(child types.DependencyInfo) {
 	d.children = append(d.children, child)
 }
 
-func (d *dependencyInfo) RequiredServiceTypes() []reflect.Type {
+func (d *dependencyInfo) RequiredServiceTypes() []types.ServiceType {
 	return d.registration.RequiredServiceTypes()
 }
 

--- a/pkg/registration/registry.go
+++ b/pkg/registration/registry.go
@@ -23,13 +23,13 @@ func RegisterSingleton(registry types.ServiceRegistry, activatorFunc any) error 
 	return registry.Register(activatorFunc, types.LifetimeSingleton)
 }
 
-func (s *serviceRegistry) addOrUpdateServiceRegistrationListFor(serviceType reflect.Type) types.ServiceRegistrationList {
-	list, exists := s.registrations[serviceType]
+func (s *serviceRegistry) addOrUpdateServiceRegistrationListFor(serviceType types.ServiceType) types.ServiceRegistrationList {
+	list, exists := s.registrations[serviceType.ReflectedType()]
 	if exists {
 		return list
 	}
 	list = NewServiceRegistrationList(s.identifierSource)
-	s.registrations[serviceType] = list
+	s.registrations[serviceType.ReflectedType()] = list
 	return list
 }
 
@@ -60,23 +60,23 @@ func (s *serviceRegistry) RegisterModule(modules ...types.ModuleFunc) error {
 	return nil
 }
 
-func (s *serviceRegistry) IsRegistered(serviceType reflect.Type) bool {
-	_, found := s.registrations[serviceType]
+func (s *serviceRegistry) IsRegistered(serviceType types.ServiceType) bool {
+	_, found := s.registrations[serviceType.ReflectedType()]
 	return found
 }
 
-func (s *serviceRegistry) TryGetServiceRegistrations(serviceType reflect.Type) (types.ServiceRegistrationList, bool) {
+func (s *serviceRegistry) TryGetServiceRegistrations(serviceType types.ServiceType) (types.ServiceRegistrationList, bool) {
 	if s.IsRegistered(serviceType) == false {
 		return nil, false
 	}
-	list, found := s.registrations[serviceType]
+	list, found := s.registrations[serviceType.ReflectedType()]
 	if found && list.IsEmpty() == false {
 		return list, true
 	}
 	return nil, false
 }
 
-func (s *serviceRegistry) TryGetSingleServiceRegistration(serviceType reflect.Type) (types.ServiceRegistration, bool) {
+func (s *serviceRegistry) TryGetSingleServiceRegistration(serviceType types.ServiceType) (types.ServiceRegistration, bool) {
 	list, found := s.TryGetServiceRegistrations(serviceType)
 	if found && list.IsEmpty() == false {
 		registrations := list.Registrations()

--- a/pkg/registration/registry_accessor.go
+++ b/pkg/registration/registry_accessor.go
@@ -2,14 +2,13 @@ package registration
 
 import (
 	"github.com/matzefriedrich/parsley/pkg/types"
-	"reflect"
 )
 
 type multiRegistryAccessor struct {
 	registries []types.ServiceRegistryAccessor
 }
 
-func (m *multiRegistryAccessor) TryGetSingleServiceRegistration(serviceType reflect.Type) (types.ServiceRegistration, bool) {
+func (m *multiRegistryAccessor) TryGetSingleServiceRegistration(serviceType types.ServiceType) (types.ServiceRegistration, bool) {
 	for _, registry := range m.registries {
 		registration, ok := registry.TryGetSingleServiceRegistration(serviceType)
 		if ok {
@@ -19,7 +18,7 @@ func (m *multiRegistryAccessor) TryGetSingleServiceRegistration(serviceType refl
 	return nil, false
 }
 
-func (m *multiRegistryAccessor) TryGetServiceRegistrations(serviceType reflect.Type) (types.ServiceRegistrationList, bool) {
+func (m *multiRegistryAccessor) TryGetServiceRegistrations(serviceType types.ServiceType) (types.ServiceRegistrationList, bool) {
 	for _, registry := range m.registries {
 		registration, ok := registry.TryGetServiceRegistrations(serviceType)
 		if ok {

--- a/pkg/registration/service_registration.go
+++ b/pkg/registration/service_registration.go
@@ -100,10 +100,10 @@ func CreateServiceRegistration(activatorFunc any, lifetimeScope types.LifetimeSc
 
 	serviceType := info.ReturnType()
 	switch serviceType.ReflectedType().Kind() {
-	case reflect.Pointer:
-		fallthrough
 	case reflect.Func:
 		return newServiceRegistration(serviceType, lifetimeScope, value), nil
+	case reflect.Pointer:
+		fallthrough
 	case reflect.Interface:
 		requiredTypes := info.ParameterTypes()
 		return newServiceRegistration(serviceType, lifetimeScope, value, requiredTypes...), nil

--- a/pkg/registration/service_registration.go
+++ b/pkg/registration/service_registration.go
@@ -18,11 +18,11 @@ type serviceRegistration struct {
 }
 
 type typeInfo struct {
-	t    reflect.Type
+	t    types.ServiceType
 	name string
 }
 
-func newTypeInfo(t reflect.Type) typeInfo {
+func newTypeInfo(t types.ServiceType) typeInfo {
 	return typeInfo{
 		t:    t,
 		name: t.Name(),
@@ -66,15 +66,15 @@ func (s *serviceRegistration) LifetimeScope() types.LifetimeScope {
 	return s.lifetimeScope
 }
 
-func (s *serviceRegistration) RequiredServiceTypes() []reflect.Type {
-	requiredTypes := make([]reflect.Type, len(s.parameters))
+func (s *serviceRegistration) RequiredServiceTypes() []types.ServiceType {
+	requiredTypes := make([]types.ServiceType, len(s.parameters))
 	for i, p := range s.parameters {
 		requiredTypes[i] = p.t
 	}
 	return requiredTypes
 }
 
-func (s *serviceRegistration) ServiceType() reflect.Type {
+func (s *serviceRegistration) ServiceType() types.ServiceType {
 	return s.serviceType.t
 }
 
@@ -99,7 +99,9 @@ func CreateServiceRegistration(activatorFunc any, lifetimeScope types.LifetimeSc
 	}
 
 	serviceType := info.ReturnType()
-	switch serviceType.Kind() {
+	switch serviceType.ReflectedType().Kind() {
+	case reflect.Pointer:
+		fallthrough
 	case reflect.Func:
 		return newServiceRegistration(serviceType, lifetimeScope, value), nil
 	case reflect.Interface:
@@ -110,7 +112,7 @@ func CreateServiceRegistration(activatorFunc any, lifetimeScope types.LifetimeSc
 	}
 }
 
-func newServiceRegistration(serviceType reflect.Type, scope types.LifetimeScope, activatorFunc reflect.Value, parameters ...reflect.Type) *serviceRegistration {
+func newServiceRegistration(serviceType types.ServiceType, scope types.LifetimeScope, activatorFunc reflect.Value, parameters ...types.ServiceType) *serviceRegistration {
 	parameterTypeInfos := make([]typeInfo, len(parameters))
 	for i, p := range parameters {
 		parameterTypeInfos[i] = newTypeInfo(p)

--- a/pkg/registration/service_type.go
+++ b/pkg/registration/service_type.go
@@ -1,7 +1,0 @@
-package registration
-
-import "reflect"
-
-func ServiceType[T any]() reflect.Type {
-	return reflect.TypeOf(new(T)).Elem()
-}

--- a/pkg/resolving/resolver.go
+++ b/pkg/resolving/resolver.go
@@ -19,10 +19,11 @@ func ResolveRequiredServices[T any](resolver types.Resolver, ctx context.Context
 	switch t.Kind() {
 	case reflect.Func:
 	case reflect.Interface:
+	case reflect.Pointer:
 	default:
 		return []T{}, types.NewResolverError(types.ErrorActivatorFunctionInvalidReturnType)
 	}
-	resolvedInstances, err := resolver.Resolve(ctx, registration.ServiceType[T]())
+	resolvedInstances, err := resolver.Resolve(ctx, types.MakeServiceType[T]())
 	if err != nil {
 		return []T{}, err
 	}
@@ -87,11 +88,11 @@ func (r *resolver) createResolverRegistryAccessor(resolverOptions ...types.Resol
 	return r.registry, nil
 }
 
-func (r *resolver) Resolve(ctx context.Context, serviceType reflect.Type) ([]interface{}, error) {
+func (r *resolver) Resolve(ctx context.Context, serviceType types.ServiceType) ([]interface{}, error) {
 	return r.ResolveWithOptions(ctx, serviceType)
 }
 
-func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType reflect.Type, resolverOptions ...types.ResolverOptionsFunc) ([]interface{}, error) {
+func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.ServiceType, resolverOptions ...types.ResolverOptionsFunc) ([]interface{}, error) {
 
 	registry, registryErr := r.createResolverRegistryAccessor(resolverOptions...)
 	if registryErr != nil {

--- a/pkg/types/service_type.go
+++ b/pkg/types/service_type.go
@@ -32,6 +32,8 @@ func ServiceTypeFrom(t reflect.Type) ServiceType {
 		name = t.Elem().String()
 	case reflect.Interface:
 		name = t.Name()
+	case reflect.Func:
+		name = t.String()
 	default:
 		panic("unsupported type: " + t.String())
 	}

--- a/pkg/types/service_type.go
+++ b/pkg/types/service_type.go
@@ -1,0 +1,42 @@
+package types
+
+import (
+	"reflect"
+)
+
+type serviceType struct {
+	reflectedType reflect.Type
+	name          string
+}
+
+func (s serviceType) ReflectedType() reflect.Type {
+	return s.reflectedType
+}
+
+func (s serviceType) Name() string {
+	return s.name
+}
+
+func MakeServiceType[T any]() ServiceType {
+	elem := reflect.TypeOf(new(T)).Elem()
+	return &serviceType{
+		reflectedType: elem,
+		name:          elem.String(),
+	}
+}
+
+func ServiceTypeFrom(t reflect.Type) ServiceType {
+	name := ""
+	switch t.Kind() {
+	case reflect.Ptr:
+		name = t.Elem().String()
+	case reflect.Interface:
+		name = t.Name()
+	default:
+		panic("unsupported type: " + t.String())
+	}
+	return &serviceType{
+		reflectedType: t,
+		name:          name,
+	}
+}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -2,20 +2,27 @@ package types
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 )
 
 type FunctionInfo interface {
+	fmt.Stringer
 	Name() string
-	ParameterTypes() []reflect.Type
-	ReturnType() reflect.Type
+	ParameterTypes() []ServiceType
+	ReturnType() ServiceType
+}
+
+type ServiceType interface {
+	Name() string
+	ReflectedType() reflect.Type
 }
 
 type ServiceRegistry interface {
 	ServiceRegistryAccessor
 	CreateLinkedRegistry() ServiceRegistry
 	CreateScope() ServiceRegistry
-	IsRegistered(serviceType reflect.Type) bool
+	IsRegistered(serviceType ServiceType) bool
 	Register(activatorFunc any, scope LifetimeScope) error
 	RegisterModule(modules ...ModuleFunc) error
 }
@@ -23,8 +30,8 @@ type ServiceRegistry interface {
 type ModuleFunc func(registry ServiceRegistry) error
 
 type ServiceRegistryAccessor interface {
-	TryGetServiceRegistrations(serviceType reflect.Type) (ServiceRegistrationList, bool)
-	TryGetSingleServiceRegistration(serviceType reflect.Type) (ServiceRegistration, bool)
+	TryGetServiceRegistrations(serviceType ServiceType) (ServiceRegistrationList, bool)
+	TryGetSingleServiceRegistration(serviceType ServiceType) (ServiceRegistration, bool)
 }
 
 type ServiceRegistration interface {
@@ -32,8 +39,8 @@ type ServiceRegistration interface {
 	InvokeActivator(params ...interface{}) (interface{}, error)
 	IsSame(other ServiceRegistration) bool
 	LifetimeScope() LifetimeScope
-	RequiredServiceTypes() []reflect.Type
-	ServiceType() reflect.Type
+	RequiredServiceTypes() []ServiceType
+	ServiceType() ServiceType
 }
 
 type ServiceRegistrationList interface {
@@ -53,8 +60,8 @@ type RegistrationConfigurationFunc func(r ServiceRegistration)
 type ResolverOptionsFunc func(registry ServiceRegistry) error
 
 type Resolver interface {
-	Resolve(ctx context.Context, serviceType reflect.Type) ([]interface{}, error)
-	ResolveWithOptions(ctx context.Context, serviceType reflect.Type, options ...ResolverOptionsFunc) ([]interface{}, error)
+	Resolve(ctx context.Context, serviceType ServiceType) ([]interface{}, error)
+	ResolveWithOptions(ctx context.Context, serviceType ServiceType, options ...ResolverOptionsFunc) ([]interface{}, error)
 }
 
 type DependencyInfo interface {
@@ -64,7 +71,7 @@ type DependencyInfo interface {
 	HasInstance() bool
 	Instance() interface{}
 	Registration() ServiceRegistration
-	RequiredServiceTypes() []reflect.Type
+	RequiredServiceTypes() []ServiceType
 	RequiredServices() ([]interface{}, error)
 	ServiceTypeName() string
 	SetInstance(instance interface{}) error


### PR DESCRIPTION
Adds support for non-interface types (both registration and resolving) 

- Allows `reflect.Pointer` type for registration and activation
- Refactors `service_type.go` module (adds struct with name and reflected type to replace all usages of `refect.Type`)
- Adds new tests