### PR TITLE
Feature/resolve named services as list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.6.1] - 2024-07-30
+
+### Changes
+
+* Registers named services as transient services to resolve them also as a list of services (like services without a name). Changes the `createResolverRegistryAccessor` method so temporary registrations are selected first (and shadow permanent registrations). This behavior can also be leveraged in `ResolverOptionsFunc` to shadow other registrations when resolving instances via `ResolveWithOptions.`
+
+
 ## [v0.6.0] - 2024-07-26
 
 ### Added 

--- a/internal/tests/features/registry_register_named_test.go
+++ b/internal/tests/features/registry_register_named_test.go
@@ -56,6 +56,33 @@ func Test_Registry_register_named_service_consume_factory(t *testing.T) {
 	assert.NotNil(t, actual.localDataService)
 }
 
+func Test_Registry_register_named_service_resolve_as_list(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = features.RegisterNamed[dataService](registry,
+		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
+		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
+
+	resolver := resolving.NewResolver(registry)
+	scopedContext := resolving.NewScopedContext(context.Background())
+
+	// Act
+	actual, err := resolving.ResolveRequiredServices[dataService](resolver, scopedContext)
+	namedServiceFactory, _ := resolving.ResolveRequiredService[func(string) (dataService, error)](resolver, scopedContext)
+	remote, _ := namedServiceFactory("remote")
+	local, _ := namedServiceFactory("local")
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, 2, len(actual))
+	assert.NotNil(t, remote)
+	assert.Equal(t, "data from remote service", remote.FetchData())
+	assert.NotNil(t, local)
+	assert.Equal(t, "data from local service", local.FetchData())
+}
+
 type dataService interface {
 	FetchData() string
 }

--- a/pkg/features/named_services.go
+++ b/pkg/features/named_services.go
@@ -24,10 +24,11 @@ func RegisterNamed[T any](registry types.ServiceRegistry, services ...registrati
 	registrationErrors := make([]error, 0)
 
 	for _, service := range services {
-		name, serviceActivatorFunc, _ := service()
+		name, serviceActivatorFunc, scope := service()
 		if len(name) == 0 || serviceActivatorFunc == nil {
 			return types.NewRegistryError("invalid named service registration")
 		}
+		registry.Register(serviceActivatorFunc, scope)
 		namedActivator := newNamedServiceFactory[T](name, serviceActivatorFunc)
 		err := registration.RegisterInstance(registry, namedActivator)
 		if err != nil {

--- a/pkg/resolving/resolver.go
+++ b/pkg/resolving/resolver.go
@@ -83,7 +83,7 @@ func (r *resolver) createResolverRegistryAccessor(resolverOptions ...types.Resol
 		if err != nil {
 			return nil, err
 		}
-		return registration.NewMultiRegistryAccessor(r.registry, transientRegistry), nil
+		return registration.NewMultiRegistryAccessor(transientRegistry, r.registry), nil
 	}
 	return r.registry, nil
 }


### PR DESCRIPTION
Automatically registers services with a name automatically with the desired lifetime scope to resolve them also as a list of services (like services without a name). Changes the `createResolverRegistryAccessor` method so temporary registrations are selected first (and shadow permanent registrations).