### PR TITLE
Feature/lazy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.0] - 2024-08-05
+
+* Adds the `RegisterLazy[T]` method to register lazy service factories. Use the type `func() Lazy[T]` to consume a lazy service dependency and call the `Value() T` method on the lazy factory to request the actual service instance. The factory will create the service instance upon the first request, cache it, and return for any subsequent calls to the `Value` method.
+
+
 ## [v0.6.1] - 2024-07-30
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.7.0] - 2024-08-05
 
-* Adds the `RegisterLazy[T]` method to register lazy service factories. Use the type `func() Lazy[T]` to consume a lazy service dependency and call the `Value() T` method on the lazy factory to request the actual service instance. The factory will create the service instance upon the first request, cache it, and return for any subsequent calls to the `Value` method.
-
+* Adds the `RegisterLazy[T]` method to register lazy service factories. Use the type `Lazy[T]` to consume a lazy service dependency and call the `Value() T` method on the lazy factory to request the actual service instance. The factory will create the service instance upon the first request, cache it, and return it for subsequent calls using the `Value` method.
 
 ## [v0.6.1] - 2024-07-30
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Though dependency injection is less prevalent in Golang (compared to other langu
 - ✔️ Bundle type registrations as modules to register them via `RegisterModule` as a unit
 - ✔️ Resolve objects on-demand
   - ✔️ Allow consumption of `Resolver` in favor of custom factories
-  - ⏳ Lazy loading objects by injecting dependencies as `Lazy[T]`
+  - ✔️ Lazy loading objects by injecting dependencies as `Lazy[T]`
   - ✔️ Register factory functions to create instances of services based on input parameters provided at runtime
   - ⏳ Validate registered services; fail early during application startup if missing registrations are encountered
   - ✔️ Provide instances for non-registered types, use `ResolveWithOptions[T]` insted of `Resolve[T]`

--- a/internal/tests/features/registry_register_lazy_service_test.go
+++ b/internal/tests/features/registry_register_lazy_service_test.go
@@ -1,0 +1,39 @@
+package features
+
+import (
+	"context"
+	"github.com/matzefriedrich/parsley/pkg/features"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Registry_register_lazy_service_type_factory(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = features.RegisterLazy[*foo](registry, func() *foo {
+		return &foo{}
+	}, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(context.Background())
+
+	// Act
+	lazyFactory, err := resolving.ResolveRequiredService[func() features.Lazy[*foo]](resolver, ctx)
+	actual := lazyFactory()
+	fooInstance0 := actual.Value()
+	fooInstance1 := actual.Value()
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, lazyFactory)
+	assert.NotNil(t, actual)
+	assert.NotNil(t, fooInstance0)
+	assert.NotNil(t, fooInstance1)
+}
+
+type foo struct {
+}

--- a/internal/tests/features/registry_register_lazy_service_test.go
+++ b/internal/tests/features/registry_register_lazy_service_test.go
@@ -22,14 +22,12 @@ func Test_Registry_register_lazy_service_type_factory(t *testing.T) {
 	ctx := resolving.NewScopedContext(context.Background())
 
 	// Act
-	lazyFactory, err := resolving.ResolveRequiredService[func() features.Lazy[*foo]](resolver, ctx)
-	actual := lazyFactory()
+	actual, err := resolving.ResolveRequiredService[features.Lazy[*foo]](resolver, ctx)
 	fooInstance0 := actual.Value()
 	fooInstance1 := actual.Value()
 
 	// Assert
 	assert.NoError(t, err)
-	assert.NotNil(t, lazyFactory)
 	assert.NotNil(t, actual)
 	assert.NotNil(t, fooInstance0)
 	assert.NotNil(t, fooInstance1)

--- a/pkg/features/lazy_services.go
+++ b/pkg/features/lazy_services.go
@@ -1,0 +1,55 @@
+package features
+
+import (
+	"github.com/matzefriedrich/parsley/internal"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"sync"
+)
+
+type lazy[T any] struct {
+	instance      T
+	activatorFunc func() T
+	m             sync.RWMutex
+}
+
+func (l *lazy[T]) Value() T {
+	l.m.RLock()
+	if internal.IsNil(l.instance) == false {
+		defer l.m.RUnlock()
+	} else {
+		l.m.RUnlock()
+		l.m.Lock()
+		defer l.m.Unlock()
+		if internal.IsNil(l.instance) {
+			instance := l.activatorFunc()
+			l.instance = instance
+		}
+	}
+	return l.instance
+}
+
+type Lazy[T any] interface {
+	Value() T
+}
+
+var _ Lazy[any] = &lazy[any]{}
+
+func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc func() T, scope types.LifetimeScope) error {
+
+	lazyActivator := newLazyServiceFactory[T](activatorFunc)
+	err := registration.RegisterInstance(registry, lazyActivator)
+	if err != nil {
+		return types.NewRegistryError("failed to register lazy service")
+	}
+
+	return nil
+}
+
+func newLazyServiceFactory[T any](activatorFunc func() T) func() Lazy[T] {
+	return func() Lazy[T] {
+		return &lazy[T]{
+			activatorFunc: activatorFunc,
+		}
+	}
+}

--- a/pkg/features/lazy_services.go
+++ b/pkg/features/lazy_services.go
@@ -46,10 +46,8 @@ func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc func() T,
 	return nil
 }
 
-func newLazyServiceFactory[T any](activatorFunc func() T) func() Lazy[T] {
-	return func() Lazy[T] {
-		return &lazy[T]{
-			activatorFunc: activatorFunc,
-		}
+func newLazyServiceFactory[T any](activatorFunc func() T) Lazy[T] {
+	return &lazy[T]{
+		activatorFunc: activatorFunc,
 	}
 }


### PR DESCRIPTION
This adds the `RegisterLazy[T]` method to register lazy service factories. 

- Lazy services can be consumed using the type `Lazy[T]`.
- The actual service instance can be retrieved by calling the `Value() T` method on the lazy factory.
- The factory will create the service instance upon the first request, cache it, and return it for subsequent calls using the `Value` method.