### PR TITLE
Fix/resolver inject list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.7.1] - 2024-08-10
+
+This version addresses issues with resolving and injecting services as lists.
+
+### Added
+
+* Adds the `RegisterList[T]` method to enable the resolver to inject lists of services. While resolving lists of a specific service type was already possible by the `ResolveRequiredServices[T]` method, the consumption of arrays in constructor functions requires an explicit registration. The list registration can be mixed with named service registrations.
+
+### Changes
+
+* Changes the key-type used to register and lookup service registrations (uses `ServiceKey` instead of `reflect.Type`). 
+
+* Adds `fmt.Stringer` implementations to registration types to improve the debugging experience. It also fixes the handling of types reflected from anonymous functions.
+
+* Extracts some registry and resolver errors.
+
+
 ## [v0.7.0] - 2024-08-05
+
+### Added
 
 * Adds the `RegisterLazy[T]` method to register lazy service factories. Use the type `Lazy[T]` to consume a lazy service dependency and call the `Value() T` method on the lazy factory to request the actual service instance. The factory will create the service instance upon the first request, cache it, and return it for subsequent calls using the `Value` method.
 

--- a/internal/tests/core/function_info_test.go
+++ b/internal/tests/core/function_info_test.go
@@ -57,7 +57,7 @@ func Test_FunctionInfo_ReflectFunctionInfoFrom_local_function_returning_an_inter
 	expected := expectedFunctionInfo{
 		functionName:             expectedAnonymousFunctionName,
 		formattedSignatureString: fmt.Sprintf("%s() core.some", expectedAnonymousFunctionName),
-		returnTypeName:           "core.some",
+		returnTypeName:           "some",
 		numParameters:            0,
 	}
 
@@ -73,7 +73,7 @@ func Test_FunctionInfo_ReflectFunctionInfoFrom_named_function_returning_an_inter
 	expected := expectedFunctionInfo{
 		functionName:             expectedFunctionName,
 		formattedSignatureString: fmt.Sprintf("%s() core.some", expectedFunctionName),
-		returnTypeName:           "core.some",
+		returnTypeName:           "some",
 		numParameters:            0,
 	}
 
@@ -89,7 +89,7 @@ func Test_FunctionInfo_ReflectFunctionInfoFrom_named_function_with_parameters_re
 	expected := expectedFunctionInfo{
 		functionName:             expectedFunctionName,
 		formattedSignatureString: fmt.Sprintf("%s(interface {}) core.some", expectedFunctionName),
-		returnTypeName:           "core.some",
+		returnTypeName:           "some",
 		numParameters:            1,
 	}
 

--- a/internal/tests/features/data_services.go
+++ b/internal/tests/features/data_services.go
@@ -1,0 +1,30 @@
+package features
+
+type dataService interface {
+	FetchData() string
+}
+
+type remoteDataService struct {
+}
+
+func newRemoteDataService() dataService {
+	return &remoteDataService{}
+}
+
+func (r *remoteDataService) FetchData() string {
+	return "data from remote service"
+}
+
+var _ dataService = &remoteDataService{}
+
+type localDataService struct{}
+
+func newLocalDataService() dataService {
+	return &localDataService{}
+}
+
+func (l *localDataService) FetchData() string {
+	return "data from local service"
+}
+
+var _ dataService = &localDataService{}

--- a/internal/tests/features/registry_register_list_test.go
+++ b/internal/tests/features/registry_register_list_test.go
@@ -16,7 +16,7 @@ func Test_Resolver_register_list_resolver(t *testing.T) {
 	registry := registration.NewServiceRegistry()
 	registry.Register(newLocalDataService, types.LifetimeTransient)
 	registry.Register(newRemoteDataService, types.LifetimeTransient)
-	features.RegisterList[dataService](registry, types.LifetimeTransient)
+	features.RegisterList[dataService](registry)
 
 	resolver := resolving.NewResolver(registry)
 	ctx := resolving.NewScopedContext(context.Background())
@@ -35,7 +35,7 @@ func Test_Resolver_resolve_multiple_instances_of_type(t *testing.T) {
 	registry := registration.NewServiceRegistry()
 	registry.Register(newLocalDataService, types.LifetimeTransient)
 	registry.Register(newRemoteDataService, types.LifetimeTransient)
-	features.RegisterList[dataService](registry, types.LifetimeTransient)
+	features.RegisterList[dataService](registry)
 	registry.Register(newControllerWithServiceList, types.LifetimeTransient)
 
 	resolver := resolving.NewResolver(registry)

--- a/internal/tests/features/registry_register_list_test.go
+++ b/internal/tests/features/registry_register_list_test.go
@@ -1,0 +1,61 @@
+package features
+
+import (
+	"context"
+	"github.com/matzefriedrich/parsley/pkg/features"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Resolver_register_list_resolver(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	registry.Register(newLocalDataService, types.LifetimeTransient)
+	registry.Register(newRemoteDataService, types.LifetimeTransient)
+	features.RegisterList[dataService](registry, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(context.Background())
+
+	// Act
+	actual, err := resolving.ResolveRequiredService[[]dataService](resolver, ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.Len(t, actual, 2)
+}
+
+func Test_Resolver_resolve_multiple_instances_of_type(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	registry.Register(newLocalDataService, types.LifetimeTransient)
+	registry.Register(newRemoteDataService, types.LifetimeTransient)
+	features.RegisterList[dataService](registry, types.LifetimeTransient)
+	registry.Register(newControllerWithServiceList, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(context.Background())
+
+	// Act
+	actual, err := resolving.ResolveRequiredService[*controllerWithServiceList](resolver, ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+
+}
+
+type controllerWithServiceList struct {
+	dataServices []dataService
+}
+
+func newControllerWithServiceList(dataServices []dataService) *controllerWithServiceList {
+	return &controllerWithServiceList{
+		dataServices: dataServices,
+	}
+}

--- a/internal/tests/features/registry_register_named_test.go
+++ b/internal/tests/features/registry_register_named_test.go
@@ -91,7 +91,7 @@ func Test_Registry_register_named_service_resolve_all_named_services_as_list(t *
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
 
-	features.RegisterList[dataService](registry, types.LifetimeTransient)
+	features.RegisterList[dataService](registry)
 
 	resolver := resolving.NewResolver(registry)
 	scopedContext := resolving.NewScopedContext(context.Background())

--- a/internal/tests/features/registry_register_named_test.go
+++ b/internal/tests/features/registry_register_named_test.go
@@ -56,7 +56,7 @@ func Test_Registry_register_named_service_consume_factory(t *testing.T) {
 	assert.NotNil(t, actual.localDataService)
 }
 
-func Test_Registry_register_named_service_resolve_as_list(t *testing.T) {
+func Test_Registry_register_named_service_resolve_all_named_services(t *testing.T) {
 
 	// Arrange
 	registry := registration.NewServiceRegistry()
@@ -83,6 +83,27 @@ func Test_Registry_register_named_service_resolve_as_list(t *testing.T) {
 	assert.Equal(t, "data from local service", local.FetchData())
 }
 
+func Test_Registry_register_named_service_resolve_all_named_services_as_list(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = features.RegisterNamed[dataService](registry,
+		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
+		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
+
+	features.RegisterList[dataService](registry, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	scopedContext := resolving.NewScopedContext(context.Background())
+
+	// Act
+	actual, err := resolving.ResolveRequiredService[[]dataService](resolver, scopedContext)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, actual)
+	assert.Equal(t, 2, len(actual))
+}
 
 type controllerWithNamedServices struct {
 	remoteDataService dataService

--- a/internal/tests/features/registry_register_named_test.go
+++ b/internal/tests/features/registry_register_named_test.go
@@ -38,7 +38,7 @@ func Test_Registry_register_named_service_consume_factory(t *testing.T) {
 
 	// Arrange
 	registry := registration.NewServiceRegistry()
-	_ = registration.RegisterSingleton(registry, newController)
+	_ = registration.RegisterSingleton(registry, newControllerWithNamedServiceFactory)
 	_ = features.RegisterNamed[dataService](registry,
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
@@ -47,7 +47,7 @@ func Test_Registry_register_named_service_consume_factory(t *testing.T) {
 	scopedContext := resolving.NewScopedContext(context.Background())
 
 	// Act
-	actual, err := resolving.ResolveRequiredService[*controller](resolver, scopedContext)
+	actual, err := resolving.ResolveRequiredService[*controllerWithNamedServices](resolver, scopedContext)
 
 	// Assert
 	assert.NoError(t, err)
@@ -83,44 +83,16 @@ func Test_Registry_register_named_service_resolve_as_list(t *testing.T) {
 	assert.Equal(t, "data from local service", local.FetchData())
 }
 
-type dataService interface {
-	FetchData() string
-}
 
-type remoteDataService struct {
-}
-
-func newRemoteDataService() dataService {
-	return &remoteDataService{}
-}
-
-func (r *remoteDataService) FetchData() string {
-	return "data from remote service"
-}
-
-var _ dataService = &remoteDataService{}
-
-type localDataService struct{}
-
-func newLocalDataService() dataService {
-	return &localDataService{}
-}
-
-func (l *localDataService) FetchData() string {
-	return "data from local service"
-}
-
-var _ dataService = &localDataService{}
-
-type controller struct {
+type controllerWithNamedServices struct {
 	remoteDataService dataService
 	localDataService  dataService
 }
 
-func newController(dataServiceFactory func(string) (dataService, error)) *controller {
+func newControllerWithNamedServiceFactory(dataServiceFactory func(string) (dataService, error)) *controllerWithNamedServices {
 	remote, _ := dataServiceFactory("remote")
 	local, _ := dataServiceFactory("local")
-	return &controller{
+	return &controllerWithNamedServices{
 		remoteDataService: remote,
 		localDataService:  local,
 	}

--- a/pkg/features/lazy_services.go
+++ b/pkg/features/lazy_services.go
@@ -35,7 +35,7 @@ type Lazy[T any] interface {
 
 var _ Lazy[any] = &lazy[any]{}
 
-func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc func() T, scope types.LifetimeScope) error {
+func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc func() T, _ types.LifetimeScope) error {
 
 	lazyActivator := newLazyServiceFactory[T](activatorFunc)
 	err := registration.RegisterInstance(registry, lazyActivator)

--- a/pkg/features/list_services.go
+++ b/pkg/features/list_services.go
@@ -6,9 +6,9 @@ import (
 	"github.com/matzefriedrich/parsley/pkg/types"
 )
 
-func RegisterList[T any](registry types.ServiceRegistry, scope types.LifetimeScope) error {
+func RegisterList[T any](registry types.ServiceRegistry) error {
 	return registry.Register(func(resolver types.Resolver) []T {
 		services, _ := resolving.ResolveRequiredServices[T](resolver, context.Background())
 		return services
-	}, scope)
+	}, types.LifetimeTransient)
 }

--- a/pkg/features/list_services.go
+++ b/pkg/features/list_services.go
@@ -1,0 +1,14 @@
+package features
+
+import (
+	"context"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+)
+
+func RegisterList[T any](registry types.ServiceRegistry, scope types.LifetimeScope) error {
+	return registry.Register(func(resolver types.Resolver) []T {
+		services, _ := resolving.ResolveRequiredServices[T](resolver, context.Background())
+		return services
+	}, scope)
+}

--- a/pkg/registration/registry.go
+++ b/pkg/registration/registry.go
@@ -44,7 +44,7 @@ func (s *serviceRegistry) Register(activatorFunc any, lifetimeScope types.Lifeti
 	list := s.addOrUpdateServiceRegistrationListFor(serviceType)
 	addRegistrationErr := list.AddRegistration(registration)
 	if addRegistrationErr != nil {
-		return types.NewRegistryError("failed to register type", types.WithCause(addRegistrationErr))
+		return types.NewRegistryError(types.ErrorFailedToRegisterType, types.WithCause(addRegistrationErr))
 	}
 
 	return nil

--- a/pkg/registration/registry.go
+++ b/pkg/registration/registry.go
@@ -3,12 +3,11 @@ package registration
 import (
 	"github.com/matzefriedrich/parsley/internal/core"
 	"github.com/matzefriedrich/parsley/pkg/types"
-	"reflect"
 )
 
 type serviceRegistry struct {
 	identifierSource core.ServiceIdSequence
-	registrations    map[reflect.Type]types.ServiceRegistrationList
+	registrations    map[types.ServiceKey]types.ServiceRegistrationList
 }
 
 func RegisterTransient(registry types.ServiceRegistry, activatorFunc any) error {
@@ -24,12 +23,12 @@ func RegisterSingleton(registry types.ServiceRegistry, activatorFunc any) error 
 }
 
 func (s *serviceRegistry) addOrUpdateServiceRegistrationListFor(serviceType types.ServiceType) types.ServiceRegistrationList {
-	list, exists := s.registrations[serviceType.ReflectedType()]
+	list, exists := s.registrations[serviceType.LookupKey()]
 	if exists {
 		return list
 	}
 	list = NewServiceRegistrationList(s.identifierSource)
-	s.registrations[serviceType.ReflectedType()] = list
+	s.registrations[serviceType.LookupKey()] = list
 	return list
 }
 
@@ -61,7 +60,7 @@ func (s *serviceRegistry) RegisterModule(modules ...types.ModuleFunc) error {
 }
 
 func (s *serviceRegistry) IsRegistered(serviceType types.ServiceType) bool {
-	_, found := s.registrations[serviceType.ReflectedType()]
+	_, found := s.registrations[serviceType.LookupKey()]
 	return found
 }
 
@@ -69,7 +68,7 @@ func (s *serviceRegistry) TryGetServiceRegistrations(serviceType types.ServiceTy
 	if s.IsRegistered(serviceType) == false {
 		return nil, false
 	}
-	list, found := s.registrations[serviceType.ReflectedType()]
+	list, found := s.registrations[serviceType.LookupKey()]
 	if found && list.IsEmpty() == false {
 		return list, true
 	}
@@ -89,7 +88,7 @@ func (s *serviceRegistry) TryGetSingleServiceRegistration(serviceType types.Serv
 }
 
 func NewServiceRegistry() types.ServiceRegistry {
-	registrations := make(map[reflect.Type]types.ServiceRegistrationList)
+	registrations := make(map[types.ServiceKey]types.ServiceRegistrationList)
 	return &serviceRegistry{
 		identifierSource: core.NewServiceId(0),
 		registrations:    registrations,
@@ -97,7 +96,7 @@ func NewServiceRegistry() types.ServiceRegistry {
 }
 
 func (s *serviceRegistry) CreateLinkedRegistry() types.ServiceRegistry {
-	registrations := make(map[reflect.Type]types.ServiceRegistrationList)
+	registrations := make(map[types.ServiceKey]types.ServiceRegistrationList)
 	return &serviceRegistry{
 		identifierSource: s.identifierSource,
 		registrations:    registrations,
@@ -105,7 +104,7 @@ func (s *serviceRegistry) CreateLinkedRegistry() types.ServiceRegistry {
 }
 
 func (s *serviceRegistry) CreateScope() types.ServiceRegistry {
-	registrations := make(map[reflect.Type]types.ServiceRegistrationList)
+	registrations := make(map[types.ServiceKey]types.ServiceRegistrationList)
 	for serviceType, registration := range s.registrations {
 		registrations[serviceType] = registration
 	}

--- a/pkg/resolving/activate.go
+++ b/pkg/resolving/activate.go
@@ -13,7 +13,7 @@ func Activate[T any](resolver types.Resolver, ctx context.Context, activatorFunc
 	lifetimeScope := types.LifetimeTransient
 	registration, registrationErr := registration.CreateServiceRegistration(activatorFunc, lifetimeScope)
 	if registrationErr != nil {
-		return nilInstance, types.NewResolverError("failed to create instance of unregistered type", types.WithCause(registrationErr))
+		return nilInstance, types.NewResolverError(types.ErrorCannotCreateInstanceOfUnregisteredType, types.WithCause(registrationErr))
 	}
 
 	serviceType := registration.ServiceType()

--- a/pkg/resolving/resolver.go
+++ b/pkg/resolving/resolver.go
@@ -20,6 +20,7 @@ func ResolveRequiredServices[T any](resolver types.Resolver, ctx context.Context
 	case reflect.Func:
 	case reflect.Interface:
 	case reflect.Pointer:
+	case reflect.Slice:
 	default:
 		return []T{}, types.NewResolverError(types.ErrorActivatorFunctionInvalidReturnType)
 	}

--- a/pkg/types/registry_error.go
+++ b/pkg/types/registry_error.go
@@ -7,12 +7,14 @@ const (
 	ErrorCannotRegisterModule                = "failed to register module"
 	ErrorTypeAlreadyRegistered               = "type already registered"
 	ErrorServiceAlreadyLinkedWithAnotherList = "service already linked with another list"
+	ErrorFailedToRegisterType                = "failed to register type"
 )
 
 var (
 	ErrRequiresFunctionValue = errors.New(ErrorRequiresFunctionValue)
 	ErrCannotRegisterModule  = errors.New(ErrorCannotRegisterModule)
 	ErrTypeAlreadyRegistered = errors.New(ErrorTypeAlreadyRegistered)
+	ErrFailedToRegisterType  = errors.New(ErrorFailedToRegisterType)
 )
 
 type registryError struct {

--- a/pkg/types/resolver_error.go
+++ b/pkg/types/resolver_error.go
@@ -3,26 +3,28 @@ package types
 import "errors"
 
 const (
-	ErrorServiceTypeNotRegistered              = "service type is not registered"
-	ErrorRequiredServiceNotRegistered          = "required service type is not registered"
-	ErrorCannotResolveService                  = "cannot resolve service"
-	ErrorAmbiguousServiceInstancesResolved     = "the resolve operation resulted in multiple service instances"
-	ErrorActivatorFunctionInvalidReturnType    = "activator function has an invalid return type"
-	ErrorCircularDependencyDetected            = "circular dependency detected"
-	ErrorCannotBuildDependencyGraph            = "failed to build dependency graph"
-	ErrorInstanceCannotBeNil                   = "instance cannot be nil"
-	ErrorServiceTypeMustBeInterface            = "service type must be an interface"
-	ErrorCannotRegisterTypeWithResolverOptions = "cannot register type with resolver options"
+	ErrorServiceTypeNotRegistered               = "service type is not registered"
+	ErrorRequiredServiceNotRegistered           = "required service type is not registered"
+	ErrorCannotResolveService                   = "cannot resolve service"
+	ErrorAmbiguousServiceInstancesResolved      = "the resolve operation resulted in multiple service instances"
+	ErrorActivatorFunctionInvalidReturnType     = "activator function has an invalid return type"
+	ErrorCircularDependencyDetected             = "circular dependency detected"
+	ErrorCannotBuildDependencyGraph             = "failed to build dependency graph"
+	ErrorInstanceCannotBeNil                    = "instance cannot be nil"
+	ErrorServiceTypeMustBeInterface             = "service type must be an interface"
+	ErrorCannotRegisterTypeWithResolverOptions  = "cannot register type with resolver options"
+	ErrorCannotCreateInstanceOfUnregisteredType = "failed to create instance of unregistered type"
 )
 
 var (
-	ErrServiceTypeNotRegistered              = errors.New(ErrorServiceTypeNotRegistered)
-	ErrActivatorFunctionInvalidReturnType    = errors.New(ErrorCannotResolveService)
-	ErrCannotBuildDependencyGraph            = errors.New(ErrorCannotBuildDependencyGraph)
-	ErrCircularDependencyDetected            = errors.New(ErrorCircularDependencyDetected)
-	ErrInstanceCannotBeNil                   = errors.New(ErrorInstanceCannotBeNil)
-	ErrServiceTypeMustBeInterface            = errors.New(ErrorServiceTypeMustBeInterface)
-	ErrCannotRegisterTypeWithResolverOptions = errors.New(ErrorCannotRegisterTypeWithResolverOptions)
+	ErrServiceTypeNotRegistered               = errors.New(ErrorServiceTypeNotRegistered)
+	ErrActivatorFunctionInvalidReturnType     = errors.New(ErrorCannotResolveService)
+	ErrCannotBuildDependencyGraph             = errors.New(ErrorCannotBuildDependencyGraph)
+	ErrCircularDependencyDetected             = errors.New(ErrorCircularDependencyDetected)
+	ErrInstanceCannotBeNil                    = errors.New(ErrorInstanceCannotBeNil)
+	ErrServiceTypeMustBeInterface             = errors.New(ErrorServiceTypeMustBeInterface)
+	ErrCannotRegisterTypeWithResolverOptions  = errors.New(ErrorCannotRegisterTypeWithResolverOptions)
+	ErrCannotCreateInstanceOfUnregisteredType = errors.New(ErrorCannotCreateInstanceOfUnregisteredType)
 )
 
 type ResolverError struct {

--- a/pkg/types/service_type.go
+++ b/pkg/types/service_type.go
@@ -1,12 +1,26 @@
 package types
 
 import (
+	"fmt"
 	"reflect"
 )
 
 type serviceType struct {
 	reflectedType reflect.Type
 	name          string
+	packagePath   string
+	list          bool
+	lookupKey     ServiceKey
+}
+
+func (s serviceType) String() string {
+	return fmt.Sprintf("Name: \"%s\", Package: \"%s\", List: %t)", s.name, s.packagePath, s.list)
+}
+
+var _ ServiceType = &serviceType{}
+
+func (s serviceType) LookupKey() ServiceKey {
+	return s.lookupKey
 }
 
 func (s serviceType) ReflectedType() reflect.Type {
@@ -17,28 +31,47 @@ func (s serviceType) Name() string {
 	return s.name
 }
 
+func (s serviceType) PackagePath() string {
+	return s.packagePath
+}
+
 func MakeServiceType[T any]() ServiceType {
 	elem := reflect.TypeOf(new(T)).Elem()
-	return &serviceType{
-		reflectedType: elem,
-		name:          elem.String(),
-	}
+	return ServiceTypeFrom(elem)
 }
 
 func ServiceTypeFrom(t reflect.Type) ServiceType {
-	name := ""
+	isList := false
+	elemType := t
 	switch t.Kind() {
 	case reflect.Ptr:
-		name = t.Elem().String()
+		elemType = t.Elem()
 	case reflect.Interface:
-		name = t.String()
+		break
 	case reflect.Func:
-		name = t.String()
+		break
+	case reflect.Slice:
+		t = t.Elem()
+		isList = true
 	default:
 		panic("unsupported type: " + t.String())
 	}
+	return newServiceType(t, elemType, isList)
+}
+
+func newServiceType(t reflect.Type, elemType reflect.Type, isList bool) ServiceType {
+	packagePath := t.PkgPath()
+	name := elemType.Name()
+	key := fmt.Sprintf("%s.%s", packagePath, name)
+	if isList {
+		key = fmt.Sprintf("%s.%s[]", packagePath, name)
+	}
+	serviceKey := ServiceKey{value: key}
 	return &serviceType{
 		reflectedType: t,
 		name:          name,
+		packagePath:   packagePath,
+		list:          isList,
+		lookupKey:     serviceKey,
 	}
 }

--- a/pkg/types/service_type.go
+++ b/pkg/types/service_type.go
@@ -61,7 +61,13 @@ func ServiceTypeFrom(t reflect.Type) ServiceType {
 
 func newServiceType(t reflect.Type, elemType reflect.Type, isList bool) ServiceType {
 	packagePath := t.PkgPath()
+	if len(packagePath) == 0 {
+		packagePath = "anonymous"
+	}
 	name := elemType.Name()
+	if len(name) == 0 {
+		name = t.String()
+	}
 	key := fmt.Sprintf("%s.%s", packagePath, name)
 	if isList {
 		key = fmt.Sprintf("%s.%s[]", packagePath, name)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -19,9 +19,19 @@ type FunctionParameterInfo interface {
 	Type() ServiceType
 }
 
+type ServiceKey struct {
+	value string
+}
+
+func (s ServiceKey) String() string {
+	return s.value
+}
+
 type ServiceType interface {
 	Name() string
+	PackagePath() string
 	ReflectedType() reflect.Type
+	LookupKey() ServiceKey
 }
 
 type ServiceRegistry interface {


### PR DESCRIPTION
* Adds the `RegisterList[T]` method to enable the resolver to inject lists of services (resolving lists of a specific service type was already possible by the `ResolveRequiredServices[T]` method, but not automatic injection of services of the same type)
* Changes the key-type used to register and lookup service registrations (uses `ServiceKey` instead of `reflect.Type`). 
* Adds `fmt.Stringer` implementations to registration types to improve the debugging experience. It also fixes the handling of types reflected from anonymous functions.
* Extracts some registry and resolver errors.
* Adds more tests.