### PR TITLE
Fixes type formatting in mock.gotmpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v0.9.2] - 2024-09-09
 
 ### Added
 
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Fixes matching of expected arguments in `mock_verify.go`
+* Adds the `FormatType` template function and fixes the type formatting for array types in default mock functions.
   
 
 ## [v0.9.1] - 2024-09-09

--- a/internal/generator/naming_functions.go
+++ b/internal/generator/naming_functions.go
@@ -5,7 +5,8 @@ import "unicode"
 func RegisterNamingFunctions(generator GenericCodeGenerator) error {
 	return generator.AddTemplateFunc(
 		NamedFunc("asPrivate", MakePrivate),
-		NamedFunc("asPublic", MakePublic))
+		NamedFunc("asPublic", MakePublic),
+	)
 }
 
 func MakePrivate(s string) string {

--- a/internal/generator/type_model_functions.go
+++ b/internal/generator/type_model_functions.go
@@ -7,12 +7,14 @@ import (
 
 func RegisterTypeModelFunctions(generator GenericCodeGenerator) error {
 	return generator.AddTemplateFunc(
-		NamedFunc("HasResults", HasResults),
-		NamedFunc("FormattedParameters", FormattedParameters),
+		NamedFunc("FormatType", FormatType),
 		NamedFunc("FormattedCallParameters", FormattedCallParameters),
+		NamedFunc("FormattedParameters", FormattedParameters),
 		NamedFunc("FormattedResultParameters", FormattedResultParameters),
 		NamedFunc("FormattedResultTypes", FormattedResultTypes),
-		NamedFunc("Signature", Signature))
+		NamedFunc("HasResults", HasResults),
+		NamedFunc("Signature", Signature),
+	)
 }
 
 func HasResults(m Method) bool {
@@ -22,10 +24,7 @@ func HasResults(m Method) bool {
 func FormattedParameters(m Method) string {
 	formattedParameters := make([]string, len(m.Parameters))
 	for i, parameter := range m.Parameters {
-		typeName := parameter.TypeName
-		if parameter.IsArray {
-			typeName = "[]" + typeName
-		}
+		typeName := FormatType(parameter)
 		formattedParameters[i] = fmt.Sprintf("%s %s", parameter.Name, typeName)
 	}
 	return strings.Join(formattedParameters, ", ")
@@ -50,10 +49,7 @@ func FormattedResultParameters(m Method) string {
 func FormattedResultTypes(m Method) string {
 	formattedResults := make([]string, len(m.Results))
 	for i, result := range m.Results {
-		typeName := result.TypeName
-		if result.IsArray {
-			typeName = "[]" + typeName
-		}
+		typeName := FormatType(result)
 		formattedResults[i] = fmt.Sprintf("%s", typeName)
 	}
 	if len(formattedResults) == 0 {
@@ -70,4 +66,12 @@ func Signature(m Method) string {
 		buffer.WriteString(fmt.Sprintf(" %s", FormattedResultTypes(m)))
 	}
 	return buffer.String()
+}
+
+func FormatType(parameter Parameter) string {
+	typeName := parameter.TypeName
+	if parameter.IsArray {
+		typeName = "[]" + typeName
+	}
+	return typeName
 }

--- a/internal/generator/type_model_functions_test.go
+++ b/internal/generator/type_model_functions_test.go
@@ -1,0 +1,45 @@
+package generator
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_FormatType_formats_parameter_type(t *testing.T) {
+	// Arrange
+	p := Parameter{IsArray: false, TypeName: "byte", Name: "data"}
+
+	// Act
+	actual := FormatType(p)
+
+	// Assert
+	assert.Equal(t, "byte", actual)
+}
+
+func Test_FormatType_formats_parameter_array_type(t *testing.T) {
+	// Arrange
+	p := Parameter{IsArray: true, TypeName: "byte", Name: "data"}
+
+	// Act
+	actual := FormatType(p)
+
+	// Assert
+	assert.Equal(t, "[]byte", actual)
+}
+
+func Test_FormattedParameters_formats_parameters(t *testing.T) {
+	// Arrange
+	p := Parameter{IsArray: true, TypeName: "byte", Name: "data"}
+
+	method := Method{
+		Name:       "Method0",
+		Parameters: []Parameter{p, {Name: "msg", TypeName: "string", IsArray: false}},
+		Results:    []Parameter{},
+	}
+
+	// Act
+	actual := FormattedParameters(method)
+
+	// Assert
+	assert.Equal(t, "data []byte, msg string", actual)
+}

--- a/internal/templates/generator/mocks.gotmpl
+++ b/internal/templates/generator/mocks.gotmpl
@@ -81,7 +81,7 @@ func New{{ $interfaceName }}Mock() *{{ $mockStructName }} {
 		{{- if HasResults . }}
         {{ .Name | asPublic }}Func: func({{ FormattedParameters . }}) {{ FormattedResultTypes . }} {
 			{{- range .Results }}
-			var {{ .Name }} {{ .TypeName }}
+			var {{ .Name }} {{ FormatType . }}
 			{{- end}}
 			return {{ FormattedResultParameters . }}
 		},


### PR DESCRIPTION
 Adds the `FormatType` template function; fixes type formatting in default mock function setup.