### PR TITLE
feature/service-validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.0] - 2024-09-21
+
+### Added
+
+- Added the `validator.go` module to the `registration` package, introducing a `Validator` service to verify service registrations:
+  - Detects missing service dependencies.
+  - Identifies circular service registrations, where services depend on themselves.
+
+
+## [v0.10.1] - 2024-09-20
+
+### Changed
+
+* Added documentation comments to all exported types and methods.
+
+
 ## [v0.10.0] - 2024-09-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ While dependency injection (DI) is less common in Golang compared to other langu
   - **Custom Factories:** Allow consumption of `Resolver` instead of custom factories.
   - **Lazy Loading:** Inject dependencies lazily using `Lazy[T]`.
   - **Factory Functions:** Register factories to create service instances dynamically at runtime.
-  - **Service Validation:** ⏳ Planned feature to validate services during startup and fail early if missing registrations are found (in progress).
+  - **Service Validation:** Validate services during startup and fail early if missing registrations or circular dependencies are found.
   - **Non-Registered Types:** Resolve non-registered types using `ResolveWithOptions[T]`.
   - **Override Type Registrations:** Provide custom service instances when resolving service instances.
 

--- a/internal/tests/registration/registry_scope_test.go
+++ b/internal/tests/registration/registry_scope_test.go
@@ -1,0 +1,42 @@
+package registration
+
+import (
+	"context"
+	"github.com/matzefriedrich/parsley/internal/tests/features"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Registry_CreateScope_inherits_registered_types(t *testing.T) {
+
+	// Arrange
+	greeterFunc := func() features.Greeter {
+		return features.NewGreeterMock()
+	}
+
+	globalRegistry := registration.NewServiceRegistry()
+	_ = globalRegistry.Register(greeterFunc, types.LifetimeTransient)
+
+	// Act
+	scopedRegistry := globalRegistry.CreateScope()
+	_ = scopedRegistry.Register(newTestService, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(scopedRegistry)
+	scopedContext := resolving.NewScopedContext(context.Background())
+	actual, _ := resolving.ResolveRequiredService[*testService](resolver, scopedContext)
+
+	// Assert
+	assert.NotNil(t, scopedRegistry)
+	assert.NotNil(t, actual)
+
+	greeterServiceType := types.MakeServiceType[features.Greeter]()
+	testServiceType := types.MakeServiceType[*testService]()
+
+	assert.True(t, globalRegistry.IsRegistered(greeterServiceType))
+	assert.False(t, globalRegistry.IsRegistered(testServiceType))
+	assert.True(t, scopedRegistry.IsRegistered(testServiceType))
+	assert.True(t, scopedRegistry.IsRegistered(greeterServiceType))
+}

--- a/internal/tests/registration/validator_test.go
+++ b/internal/tests/registration/validator_test.go
@@ -1,6 +1,8 @@
 package registration
 
 import (
+	"errors"
+	"fmt"
 	"github.com/matzefriedrich/parsley/internal/tests/features"
 	"github.com/matzefriedrich/parsley/pkg/registration"
 	"github.com/matzefriedrich/parsley/pkg/types"
@@ -49,6 +51,36 @@ func Test_Validator_Validate_missing_dependency_does_return_error(t *testing.T) 
 
 	// Assert
 	assert.ErrorIs(t, err, registration.ErrRegistryMissesRequiredServiceRegistrations)
+
+	var aggregateErr *types.ParsleyAggregateError
+	if errors.As(err, &aggregateErr) {
+		for _, e := range aggregateErr.Errors() {
+			fmt.Println(e.Error())
+		}
+	}
+}
+
+func Test_Validator_Validate_detects_circular_dependencies_and_returns_error(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registry.Register(newTestService2, types.LifetimeTransient)
+	_ = registry.Register(newTestService3, types.LifetimeTransient)
+
+	sut := registration.NewServiceRegistrationsValidator()
+
+	// Act
+	err := sut.Validate(registry)
+
+	// Assert
+	assert.ErrorIs(t, err, registration.ErrCircularDependencyDetected)
+
+	var aggregateErr *types.ParsleyAggregateError
+	if errors.As(err, &aggregateErr) {
+		for _, e := range aggregateErr.Errors() {
+			fmt.Println(e.Error())
+		}
+	}
 }
 
 type testService struct {
@@ -58,5 +90,25 @@ type testService struct {
 func newTestService(greeter features.Greeter) *testService {
 	return &testService{
 		greeter: greeter,
+	}
+}
+
+type testService2 struct {
+	other *testService3
+}
+
+func newTestService2(other *testService3) *testService2 {
+	return &testService2{
+		other: other,
+	}
+}
+
+type testService3 struct {
+	other *testService2
+}
+
+func newTestService3(other *testService2) *testService3 {
+	return &testService3{
+		other: other,
 	}
 }

--- a/internal/tests/registration/validator_test.go
+++ b/internal/tests/registration/validator_test.go
@@ -1,0 +1,62 @@
+package registration
+
+import (
+	"github.com/matzefriedrich/parsley/internal/tests/features"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_Validator_Validate_on_empty_registry_does_not_return_error(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	sut := registration.NewServiceRegistrationsValidator()
+
+	// Act
+	err := sut.Validate(registry)
+
+	// Assert
+	assert.NoError(t, err)
+}
+
+func Test_Validator_Validate_single_service_with_no_dependency_does_not_return_error(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registry.Register(features.NewGreeterMock, types.LifetimeTransient)
+
+	sut := registration.NewServiceRegistrationsValidator()
+
+	// Act
+	err := sut.Validate(registry)
+
+	// Assert
+	assert.NoError(t, err)
+}
+
+func Test_Validator_Validate_missing_dependency_does_return_error(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registry.Register(newTestService, types.LifetimeTransient)
+
+	sut := registration.NewServiceRegistrationsValidator()
+
+	// Act
+	err := sut.Validate(registry)
+
+	// Assert
+	assert.ErrorIs(t, err, registration.ErrRegistryMissesRequiredServiceRegistrations)
+}
+
+type testService struct {
+	greeter features.Greeter
+}
+
+func newTestService(greeter features.Greeter) *testService {
+	return &testService{
+		greeter: greeter,
+	}
+}

--- a/internal/tests/registration/validator_test.go
+++ b/internal/tests/registration/validator_test.go
@@ -73,7 +73,7 @@ func Test_Validator_Validate_detects_circular_dependencies_and_returns_error(t *
 	err := sut.Validate(registry)
 
 	// Assert
-	assert.ErrorIs(t, err, registration.ErrCircularDependencyDetected)
+	assert.ErrorIs(t, err, registration.ErrCircularServiceRegistrationDetected)
 
 	var aggregateErr *types.ParsleyAggregateError
 	if errors.As(err, &aggregateErr) {

--- a/internal/tests/utils/map_test.go
+++ b/internal/tests/utils/map_test.go
@@ -1,0 +1,20 @@
+package utils
+
+import (
+	"github.com/matzefriedrich/parsley/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"strconv"
+	"testing"
+)
+
+func Test_Map_convert_slice(t *testing.T) {
+	// Arrange
+	source := []string{"1", "2", "3"}
+	// Act
+	actual := utils.Map(source, func(s string) int {
+		value, _ := strconv.Atoi(s)
+		return value
+	})
+	// Assert
+	assert.Equal(t, []int{1, 2, 3}, actual)
+}

--- a/internal/utils/map.go
+++ b/internal/utils/map.go
@@ -1,0 +1,10 @@
+package utils
+
+// Map applies a given function to each element of a slice and returns a new slice containing the results of the function.
+func Map[S ~[]E, E any, V any](ts S, fn func(E) V) []V {
+	result := make([]V, len(ts))
+	for i, t := range ts {
+		result[i] = fn(t)
+	}
+	return result
+}

--- a/pkg/registration/registry.go
+++ b/pkg/registration/registry.go
@@ -36,6 +36,15 @@ func (s *serviceRegistry) addOrUpdateServiceRegistrationListFor(serviceType type
 	return list
 }
 
+// GetServiceRegistrations retrieves all registered services as a slice of ServiceRegistration.
+func (s *serviceRegistry) GetServiceRegistrations() ([]types.ServiceRegistration, error) {
+	registrations := make([]types.ServiceRegistration, 0)
+	for _, list := range s.registrations {
+		registrations = append(registrations, list.Registrations()...)
+	}
+	return registrations, nil
+}
+
 // Register adds a service registration with the provided activator function and lifetime scope.
 func (s *serviceRegistry) Register(activatorFunc any, lifetimeScope types.LifetimeScope) error {
 
@@ -105,6 +114,7 @@ func NewServiceRegistry() types.ServiceRegistry {
 	}
 }
 
+// CreateLinkedRegistry creates and returns a new, empty ServiceRegistry instance linked to the current registry.
 func (s *serviceRegistry) CreateLinkedRegistry() types.ServiceRegistry {
 	registrations := make(map[types.ServiceKey]types.ServiceRegistrationList)
 	return &serviceRegistry{
@@ -113,6 +123,7 @@ func (s *serviceRegistry) CreateLinkedRegistry() types.ServiceRegistry {
 	}
 }
 
+// CreateScope creates and returns a scoped types.ServiceRegistry instance that inherits all service registrations from the current registry.
 func (s *serviceRegistry) CreateScope() types.ServiceRegistry {
 	registrations := make(map[types.ServiceKey]types.ServiceRegistrationList)
 	for serviceType, registration := range s.registrations {

--- a/pkg/registration/validator.go
+++ b/pkg/registration/validator.go
@@ -21,8 +21,8 @@ var (
 	// ErrRegistryMissesRequiredServiceRegistrations indicates that required service registrations are missing.
 	ErrRegistryMissesRequiredServiceRegistrations = types.NewRegistryError(ErrorRegistryMissesRequiredServiceRegistrations)
 
-	// ErrCircularDependencyDetected signifies that a circular dependency was encountered.
-	ErrCircularDependencyDetected = types.NewResolverError(ErrorCircularServiceRegistrationDetected)
+	// ErrCircularServiceRegistrationDetected signifies that a circular service registration was encountered.
+	ErrCircularServiceRegistrationDetected = types.NewResolverError(ErrorCircularServiceRegistrationDetected)
 )
 
 // Validator defines an interface to validate service registries..

--- a/pkg/registration/validator.go
+++ b/pkg/registration/validator.go
@@ -10,20 +10,32 @@ import (
 const (
 	ErrorFailedToRetrieveServiceRegistrations       = "failed to retrieve service registrations"
 	ErrorRegistryMissesRequiredServiceRegistrations = "the registry misses required service registrations"
+	ErrorCircularDependencyDetected                 = "circular dependencies detected"
 )
 
 var (
-	ErrFailedToRetrieveServiceRegistrations       = types.NewRegistryError(ErrorFailedToRetrieveServiceRegistrations)
+
+	// ErrFailedToRetrieveServiceRegistrations signifies an error encountered while attempting to retrieve service registrations.
+	ErrFailedToRetrieveServiceRegistrations = types.NewRegistryError(ErrorFailedToRetrieveServiceRegistrations)
+
+	// ErrRegistryMissesRequiredServiceRegistrations indicates that required service registrations are missing.
 	ErrRegistryMissesRequiredServiceRegistrations = types.NewRegistryError(ErrorRegistryMissesRequiredServiceRegistrations)
+
+	// ErrCircularDependencyDetected signifies that a circular dependency was encountered.
+	ErrCircularDependencyDetected = types.NewResolverError(types.ErrorCircularDependencyDetected)
 )
 
+// Validator defines an interface to validate service registries..
 type Validator interface {
+
+	// Validate checks the provided ServiceRegistry for missing, invalid, or circular service dependencies. Returns an error if any issues are found.
 	Validate(registry types.ServiceRegistry) error
 }
 
 type serviceRegistrationsValidator struct {
 }
 
+// Validate ensures that all required service registrations are present and service do not depend on them-selves (prevents circular dependencies).
 func (s *serviceRegistrationsValidator) Validate(registry types.ServiceRegistry) error {
 
 	registrations, err := registry.GetServiceRegistrations()
@@ -40,7 +52,7 @@ func (s *serviceRegistrationsValidator) Validate(registry types.ServiceRegistry)
 		stack.Push(registration)
 	}
 
-	for stack.IsEmpty() == false {
+	for stack.Any() {
 		next := stack.Pop()
 		nextId := next.Id()
 		_, seen := checkedServiceTypes[nextId]
@@ -68,11 +80,58 @@ func (s *serviceRegistrationsValidator) Validate(registry types.ServiceRegistry)
 		return types.NewRegistryError(ErrorRegistryMissesRequiredServiceRegistrations, types.WithAggregatedCause(errors...))
 	}
 
+	circularDependencyErrors := make([]error, 0)
+	for _, registration := range registrations {
+		if dependencyError := detectCircularDependency(registration, registry); dependencyError != nil {
+			serviceType := registration.ServiceType()
+			circularDependencyError := types.NewRegistryError(ErrorCircularDependencyDetected,
+				types.WithCause(dependencyError),
+				types.ForServiceType(serviceType.Name()))
+			circularDependencyErrors = append(circularDependencyErrors, circularDependencyError)
+		}
+	}
+
+	if len(circularDependencyErrors) > 0 {
+		return types.NewRegistryError(ErrorCircularDependencyDetected, types.WithAggregatedCause(circularDependencyErrors...))
+	}
+
+	return nil
+}
+
+func detectCircularDependency(sr types.ServiceRegistration, registry types.ServiceRegistry) error {
+
+	stack := internal.MakeStack[types.ServiceRegistration]()
+
+	pushRequiredServices := func(r types.ServiceRegistration) {
+		requiredServices := r.RequiredServiceTypes()
+		for _, serviceType := range requiredServices {
+			list, found := registry.TryGetServiceRegistrations(serviceType)
+			if found == false {
+				continue
+			}
+			for _, item := range list.Registrations() {
+				stack.Push(item)
+			}
+		}
+	}
+
+	pushRequiredServices(sr)
+
+	for stack.Any() {
+		next := stack.Pop()
+		if next.Id() == sr.Id() {
+			serviceType := sr.ServiceType()
+			return fmt.Errorf("circular dependency detected for service type %s", serviceType.Name())
+		}
+		pushRequiredServices(next)
+	}
+
 	return nil
 }
 
 var _ Validator = (*serviceRegistrationsValidator)(nil)
 
+// NewServiceRegistrationsValidator creates a new Validator instance.
 func NewServiceRegistrationsValidator() Validator {
 	return &serviceRegistrationsValidator{}
 }

--- a/pkg/registration/validator.go
+++ b/pkg/registration/validator.go
@@ -1,0 +1,78 @@
+package registration
+
+import (
+	"fmt"
+	"github.com/matzefriedrich/parsley/internal"
+	"github.com/matzefriedrich/parsley/internal/utils"
+	"github.com/matzefriedrich/parsley/pkg/types"
+)
+
+const (
+	ErrorFailedToRetrieveServiceRegistrations       = "failed to retrieve service registrations"
+	ErrorRegistryMissesRequiredServiceRegistrations = "the registry misses required service registrations"
+)
+
+var (
+	ErrFailedToRetrieveServiceRegistrations       = types.NewRegistryError(ErrorFailedToRetrieveServiceRegistrations)
+	ErrRegistryMissesRequiredServiceRegistrations = types.NewRegistryError(ErrorRegistryMissesRequiredServiceRegistrations)
+)
+
+type Validator interface {
+	Validate(registry types.ServiceRegistry) error
+}
+
+type serviceRegistrationsValidator struct {
+}
+
+func (s *serviceRegistrationsValidator) Validate(registry types.ServiceRegistry) error {
+
+	registrations, err := registry.GetServiceRegistrations()
+	if err != nil {
+		return types.NewRegistryError(ErrorFailedToRetrieveServiceRegistrations, types.WithCause(err))
+	}
+
+	missingRegistrations := make([]types.ServiceType, 0)
+
+	checkedServiceTypes := make(map[uint64]struct{})
+
+	stack := internal.MakeStack[types.ServiceRegistration]()
+	for _, registration := range registrations {
+		stack.Push(registration)
+	}
+
+	for stack.IsEmpty() == false {
+		next := stack.Pop()
+		nextId := next.Id()
+		_, seen := checkedServiceTypes[nextId]
+		if seen {
+			continue
+		}
+		dependencies := next.RequiredServiceTypes()
+		for _, dependency := range dependencies {
+			list, found := registry.TryGetServiceRegistrations(dependency)
+			if found == false {
+				missingRegistrations = append(missingRegistrations, dependency)
+				continue
+			}
+			for _, item := range list.Registrations() {
+				stack.Push(item)
+			}
+		}
+		checkedServiceTypes[nextId] = struct{}{}
+	}
+
+	if len(missingRegistrations) > 0 {
+		errors := utils.Map(missingRegistrations, func(serviceType types.ServiceType) error {
+			return fmt.Errorf("missing service registration for service type %s", serviceType)
+		})
+		return types.NewRegistryError(ErrorRegistryMissesRequiredServiceRegistrations, types.WithAggregatedCause(errors...))
+	}
+
+	return nil
+}
+
+var _ Validator = (*serviceRegistrationsValidator)(nil)
+
+func NewServiceRegistrationsValidator() Validator {
+	return &serviceRegistrationsValidator{}
+}

--- a/pkg/types/parsley_error.go
+++ b/pkg/types/parsley_error.go
@@ -58,6 +58,11 @@ type ParsleyAggregateError struct {
 	Msg    string
 }
 
+// Errors returns the slice of errors contained within ParsleyAggregateError.
+func (f ParsleyAggregateError) Errors() []error {
+	return f.errors
+}
+
 // Error returns the message associated with the ParsleyAggregateError.
 func (f ParsleyAggregateError) Error() string {
 	return f.Msg

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -61,6 +61,9 @@ type ServiceRegistry interface {
 	// CreateScope creates and returns a scoped ServiceRegistry instance which inherits all service registrations from the current ServiceRegistry instance.
 	CreateScope() ServiceRegistry
 
+	// GetServiceRegistrations retrieves all service registrations.
+	GetServiceRegistrations() ([]ServiceRegistration, error)
+
 	// IsRegistered checks if a service of the specified ServiceType is registered in the service registry.
 	IsRegistered(serviceType ServiceType) bool
 


### PR DESCRIPTION
Adds the `validator.go` module that provides functionality to validate service registrations. This module can be used to find dependencies with unregistered service types.

### Usage

```go
func main() {
  registry := registration.NewServiceRegistry()
  registryValidator := registration.NewServiceRegistrationsValidator()
  err := registryValidator.Validate(registry)
  if err != nil {
    panic(err)
  }
}
```