### PR TITLE
Pre release/init command tests

### DIFF
--- a/cmd/parsley-cli/main.go
+++ b/cmd/parsley-cli/main.go
@@ -17,8 +17,12 @@ func main() {
 
 	app := charmer.NewCommandLineApplication("parsley-cli", description)
 
+	writerFactoryFunc := func(projectFolder string) (generator.ScaffoldingFileWriterFunc, error) {
+		return commands.NewProjectFileScaffoldingWriterFactory(projectFolder), nil
+	}
+
 	app.AddCommand(
-		commands.NewInitCommand(),
+		commands.NewInitCommand(writerFactoryFunc, commands.LoadProjectFromDisk),
 		commands.NewVersionCommand(&http.Client{}))
 
 	app.AddGroupCommand(

--- a/internal/commands/init_command.go
+++ b/internal/commands/init_command.go
@@ -3,7 +3,9 @@ package commands
 import (
 	"fmt"
 	"github.com/matzefriedrich/parsley/internal/utils"
+	"io"
 	"os"
+	"path"
 
 	"github.com/matzefriedrich/cobra-extensions/pkg"
 	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
@@ -11,14 +13,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// ScaffoldingFileWriterFactoryFunc defines a function type that returns a generator.ScaffoldingFileWriterFunc.
+type ScaffoldingFileWriterFactoryFunc func(projectFolder string) (generator.ScaffoldingFileWriterFunc, error)
+
+type ProjectLoaderFunc func(projectFolderPath string) (generator.GoProject, error)
+
 type initCommand struct {
-	use abstractions.CommandName `flag:"init" short:"Add Parsley to an application"`
+	use                   abstractions.CommandName `flag:"init" short:"Add Parsley to an application"`
+	fileWriterFactoryFunc ScaffoldingFileWriterFactoryFunc
+	projectLoadFunc       ProjectLoaderFunc
 }
 
 func (g *initCommand) Execute() {
 
 	projectFolderPath, _ := os.Getwd()
-	p, err := generator.OpenProject(projectFolderPath)
+	p, err := g.projectLoadFunc(projectFolderPath)
 	if err != nil {
 		fmt.Println(err)
 		return
@@ -32,13 +41,37 @@ func (g *initCommand) Execute() {
 		return
 	}
 
-	gen := generator.NewBootstrapGenerator(projectFolderPath)
-	gen.GenerateProjectFiles()
+	fileWriterFunc, _ := g.fileWriterFactoryFunc(projectFolderPath)
+
+	gen := generator.NewBootstrapGenerator(fileWriterFunc)
+	gen.ScaffoldProjectFiles()
 }
 
 var _ pkg.TypedCommand = &initCommand{}
 
-func NewInitCommand() *cobra.Command {
-	command := &initCommand{}
+func NewInitCommand(
+	writerFactoryFunc ScaffoldingFileWriterFactoryFunc,
+	projectLoaderFunc ProjectLoaderFunc) *cobra.Command {
+	command := &initCommand{
+		fileWriterFactoryFunc: writerFactoryFunc,
+		projectLoadFunc:       projectLoaderFunc,
+	}
 	return pkg.CreateTypedCommand(command)
+}
+
+// NewProjectFileScaffoldingWriterFactory creates a factory for generating file writers in a specified project directory.
+func NewProjectFileScaffoldingWriterFactory(projectFolderPath string) generator.ScaffoldingFileWriterFunc {
+	return func(targetFilename string) (io.WriteCloser, error) {
+		targetFilePath := path.Join(projectFolderPath, targetFilename)
+		f, fileErr := os.OpenFile(targetFilePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+		if fileErr != nil {
+			return nil, fileErr
+		}
+		return f, nil
+	}
+}
+
+// LoadProjectFromDisk loads a Go project from the specified directory path.
+func LoadProjectFromDisk(projectFolderPath string) (generator.GoProject, error) {
+	return generator.OpenProject(projectFolderPath)
 }

--- a/internal/generator/project.go
+++ b/internal/generator/project.go
@@ -8,22 +8,29 @@ import (
 	"golang.org/x/mod/modfile"
 )
 
-type GoProject struct {
+type goProject struct {
 	modFilePath string
 }
 
-func OpenProject(projectFolderPath string) (*GoProject, error) {
+type GoProject interface {
+	AddDependency(packageName string, version string) error
+}
+
+var _ GoProject = (*goProject)(nil)
+
+// OpenProject opens an existing Go project from the specified folder path and returns a GoProject instance.
+func OpenProject(projectFolderPath string) (GoProject, error) {
 	modFilePath, found := findModFile(projectFolderPath)
 	if !found {
 		return nil, newProjectError("go.mod file not found", nil)
 	}
-	return &GoProject{
+	return &goProject{
 		modFilePath: modFilePath,
 	}, nil
 }
 
 // AddDependency Adds the specified package to the current project.
-func (p *GoProject) AddDependency(packageName string, version string) error {
+func (p *goProject) AddDependency(packageName string, version string) error {
 
 	data, err := os.ReadFile(p.modFilePath)
 	if err != nil {

--- a/internal/tests/commands/init_command_test.go
+++ b/internal/tests/commands/init_command_test.go
@@ -1,0 +1,64 @@
+package commands
+
+import (
+	"github.com/matzefriedrich/parsley/internal/commands"
+	"github.com/matzefriedrich/parsley/internal/generator"
+	"github.com/matzefriedrich/parsley/internal/tests/mocks"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+func Test_InitCommand_Execute_adds_project_reference_and_scaffolds_files(t *testing.T) {
+
+	// Arrange
+	expectedProjectFiles := []string{"application.go", "main.go", "greeter.go"}
+	files := make(map[string]mocks.MemoryFile)
+
+	writerFactory := func(projectFolder string) (generator.ScaffoldingFileWriterFunc, error) {
+		return func(targetFilename string) (io.WriteCloser, error) {
+			f, found := files[targetFilename]
+			if found {
+				return f, nil
+			}
+			f = mocks.NewMemoryFile()
+			files[targetFilename] = f
+			return f, nil
+		}, nil
+	}
+
+	projectInstance := &memoryGoProject{
+		packages: make(map[string]string),
+	}
+
+	sut := commands.NewInitCommand(writerFactory, func(projectFolderPath string) (generator.GoProject, error) {
+		return projectInstance, nil
+	})
+
+	// Act
+	err := sut.Execute()
+
+	// Assert
+	assert.NoError(t, err)
+
+	_, hasParsleyReference := projectInstance.packages["github.com/matzefriedrich/parsley"]
+	assert.True(t, hasParsleyReference)
+
+	for _, expectedProjectFile := range expectedProjectFiles {
+		_, found := files[expectedProjectFile]
+		if !found {
+			t.Errorf("Expected project file %s not found", expectedProjectFile)
+		}
+	}
+}
+
+type memoryGoProject struct {
+	packages map[string]string
+}
+
+func (m *memoryGoProject) AddDependency(packageName string, version string) error {
+	m.packages[packageName] = version
+	return nil
+}
+
+var _ generator.GoProject = (*memoryGoProject)(nil)

--- a/internal/tests/generator/bootstrap_generator_test.go
+++ b/internal/tests/generator/bootstrap_generator_test.go
@@ -1,0 +1,42 @@
+package generator
+
+import (
+	"github.com/matzefriedrich/parsley/internal/generator"
+	"github.com/matzefriedrich/parsley/internal/tests/mocks"
+	"io"
+	"testing"
+)
+
+func Test_BootstrapGenerator_ScaffoldProjectFiles_generates_expected_project_files(t *testing.T) {
+
+	// Arrange
+	expectedProjectFiles := []string{"application.go", "main.go", "greeter.go"}
+	memoryFiles := make(map[string]mocks.MemoryFile)
+	writerFuncFactory := func(targetFilename string) (io.WriteCloser, error) {
+		f, found := memoryFiles[targetFilename]
+		if found {
+			return f, nil
+		}
+		f = mocks.NewMemoryFile()
+		memoryFiles[targetFilename] = f
+		return f, nil
+	}
+
+	sut := generator.NewBootstrapGenerator(writerFuncFactory)
+
+	// Act
+	sut.ScaffoldProjectFiles()
+
+	// Assert
+	for _, expectedProjectFile := range expectedProjectFiles {
+		file, found := memoryFiles[expectedProjectFile]
+		if !found {
+			t.Errorf("Expected project file %s not found", expectedProjectFile)
+		}
+		content := file.String()
+		if len(content) == 0 {
+			t.Errorf("Expected project file %s to have content", expectedProjectFile)
+		}
+		t.Logf("Project file %s has content:\n%s", expectedProjectFile, content)
+	}
+}


### PR DESCRIPTION
Refactors the `init` command to use dependency injection for project loading and file writing, increasing testability and maintainability.

It introduces new interfaces, `ScaffoldingFileWriterFactoryFunc` and `ProjectLoaderFunc`, which provide more flexibility and decouple the code from direct file system interactions.

The `bootstrapGenerator` type is also modified to use the writer function, facilitating better testing. A new test is also added to verify that the bootstrap generator correctly scaffolds the necessary project files. To support these changes, new factory functions `NewProjectFileScaffoldingWriterFactory` and `LoadProjectFromDisk` are introduced.