### PR TITLE
Update cobra-extensions to v0.3.0 and refactor import paths

### DIFF
--- a/cmd/parsley-cli/main.go
+++ b/cmd/parsley-cli/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/matzefriedrich/cobra-extensions/pkg/charmer"
+	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/matzefriedrich/parsley/internal/commands"
 	"github.com/matzefriedrich/parsley/internal/generator"
 	"net/http"
@@ -27,7 +28,7 @@ func main() {
 
 	app.AddGroupCommand(
 		commands.NewGenerateGroupCommand(),
-		func(w charmer.CommandSetup) {
+		func(w types.CommandSetup) {
 			goFileAccessor := generator.GoFileAccessor()
 			outputWriterFactory := generator.FileOutputWriter()
 			w.AddCommand(commands.NewGenerateMocksCommand(goFileAccessor, outputWriterFactory))

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/hashicorp/go-version v1.7.0
-	github.com/matzefriedrich/cobra-extensions v0.2.6
+	github.com/matzefriedrich/cobra-extensions v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKe
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/matzefriedrich/cobra-extensions v0.2.6 h1:tn4w3lpEGu7eMmk4mrHF+jNdTUQKT/8P6Y7q14ZLfFI=
-github.com/matzefriedrich/cobra-extensions v0.2.6/go.mod h1:OFsBhnlLU/9lOSG6yV487NzPySnufAuzX9UkzCTgAa8=
+github.com/matzefriedrich/cobra-extensions v0.3.0 h1:otQZ2wIX9wGnLC9h3O1WUHqG/Hlb0h7Xa/wgXLsOghk=
+github.com/matzefriedrich/cobra-extensions v0.3.0/go.mod h1:0rRzEw+dJIeKQYGACR/1bj+kBbD9aSdCjSZFlQfC0tU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/commands/generate_mocks_command.go
+++ b/internal/commands/generate_mocks_command.go
@@ -3,8 +3,8 @@ package commands
 import (
 	"errors"
 	"fmt"
-	"github.com/matzefriedrich/cobra-extensions/pkg"
-	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
+	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
+	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/matzefriedrich/parsley/internal/generator"
 	"github.com/matzefriedrich/parsley/internal/reflection"
 	"github.com/matzefriedrich/parsley/internal/templates"
@@ -14,7 +14,7 @@ import (
 )
 
 type mocksGeneratorCommand struct {
-	use                 abstractions.CommandName `flag:"mocks" short:"Generate configurable mocks for interface types."`
+	use                 types.CommandName `flag:"mocks" short:"Generate configurable mocks for interface types."`
 	fileAccessor        reflection.AstFileAccessor
 	outputWriterFactory generator.OutputWriterFactory
 }
@@ -111,7 +111,7 @@ func filterInterfaces(m *reflection.Model) []reflection.Interface {
 	}
 }
 
-var _ pkg.TypedCommand = (*mocksGeneratorCommand)(nil)
+var _ types.TypedCommand = (*mocksGeneratorCommand)(nil)
 
 // NewGenerateMocksCommand creates a new cobra command to generate mock implementations for interfaces.
 // This command uses the provided file accessor to read the source file and the output writer factory to write the generated mocks.
@@ -126,7 +126,7 @@ func NewGenerateMocksCommand(fileAccessor reflection.AstFileAccessor, outputWrit
 		fileAccessor:        fileAccessor,
 		outputWriterFactory: outputWriterFactory,
 	}
-	return pkg.CreateTypedCommand(command)
+	return commands.CreateTypedCommand(command)
 }
 
 func determineMockGeneratorBehavior(m *reflection.Model) MocksGeneratorBehavior {

--- a/internal/commands/generate_proxy_command.go
+++ b/internal/commands/generate_proxy_command.go
@@ -2,8 +2,8 @@ package commands
 
 import (
 	"fmt"
-	"github.com/matzefriedrich/cobra-extensions/pkg"
-	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
+	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
+	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/matzefriedrich/parsley/internal/generator"
 	"github.com/matzefriedrich/parsley/internal/reflection"
 	"github.com/matzefriedrich/parsley/internal/templates"
@@ -11,7 +11,7 @@ import (
 )
 
 type generateProxyCommand struct {
-	use                 abstractions.CommandName `flag:"proxy" short:"Generate generic proxy types for method call interception."`
+	use                 types.CommandName `flag:"proxy" short:"Generate generic proxy types for method call interception."`
 	fileAccessor        reflection.AstFileAccessor
 	outputWriterFactory generator.OutputWriterFactory
 }
@@ -38,7 +38,7 @@ func (g *generateProxyCommand) Execute() {
 	}
 }
 
-var _ pkg.TypedCommand = &generateProxyCommand{}
+var _ types.TypedCommand = &generateProxyCommand{}
 
 // NewGenerateProxyCommand creates a new cobra.Command for generating proxy code, enabling method call interception for interfaces.
 func NewGenerateProxyCommand(fileAccessor reflection.AstFileAccessor, outputWriterFactory generator.OutputWriterFactory) *cobra.Command {
@@ -46,5 +46,5 @@ func NewGenerateProxyCommand(fileAccessor reflection.AstFileAccessor, outputWrit
 		fileAccessor:        fileAccessor,
 		outputWriterFactory: outputWriterFactory,
 	}
-	return pkg.CreateTypedCommand(command)
+	return commands.CreateTypedCommand(command)
 }

--- a/internal/commands/generator_command.go
+++ b/internal/commands/generator_command.go
@@ -1,22 +1,22 @@
 package commands
 
 import (
-	"github.com/matzefriedrich/cobra-extensions/pkg"
-	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
+	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
+	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/spf13/cobra"
 )
 
 type generatorCommand struct {
-	use abstractions.CommandName `flag:"generate" short:"Generate boilerplate code for advanced DI features."`
+	use types.CommandName `flag:"generate" short:"Generate boilerplate code for advanced DI features."`
 }
 
 func (g *generatorCommand) Execute() {
 
 }
 
-var _ pkg.TypedCommand = &generatorCommand{}
+var _ types.TypedCommand = &generatorCommand{}
 
 func NewGenerateGroupCommand() *cobra.Command {
 	command := &generatorCommand{}
-	return pkg.CreateTypedCommand(command)
+	return commands.CreateTypedCommand(command)
 }

--- a/internal/commands/init_command.go
+++ b/internal/commands/init_command.go
@@ -2,13 +2,13 @@ package commands
 
 import (
 	"fmt"
+	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
+	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/matzefriedrich/parsley/internal/utils"
 	"io"
 	"os"
 	"path"
 
-	"github.com/matzefriedrich/cobra-extensions/pkg"
-	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
 	"github.com/matzefriedrich/parsley/internal/generator"
 	"github.com/spf13/cobra"
 )
@@ -20,7 +20,7 @@ type ScaffoldingFileWriterFactoryFunc func(projectFolder string) (generator.Scaf
 type ProjectLoaderFunc func(projectFolderPath string) (generator.GoProject, error)
 
 type initCommand struct {
-	use                   abstractions.CommandName `flag:"init" short:"Add Parsley to an application"`
+	use                   types.CommandName `flag:"init" short:"Add Parsley to an application"`
 	fileWriterFactoryFunc ScaffoldingFileWriterFactoryFunc
 	projectLoadFunc       ProjectLoaderFunc
 }
@@ -50,7 +50,7 @@ func (g *initCommand) Execute() {
 	gen.ScaffoldProjectFiles()
 }
 
-var _ pkg.TypedCommand = &initCommand{}
+var _ types.TypedCommand = &initCommand{}
 
 func NewInitCommand(
 	writerFactoryFunc ScaffoldingFileWriterFactoryFunc,
@@ -59,7 +59,7 @@ func NewInitCommand(
 		fileWriterFactoryFunc: writerFactoryFunc,
 		projectLoadFunc:       projectLoaderFunc,
 	}
-	return pkg.CreateTypedCommand(command)
+	return commands.CreateTypedCommand(command)
 }
 
 // NewProjectFileScaffoldingWriterFactory creates a factory for generating file writers in a specified project directory.

--- a/internal/commands/version_command.go
+++ b/internal/commands/version_command.go
@@ -3,15 +3,15 @@ package commands
 import (
 	"context"
 	"fmt"
-	"github.com/matzefriedrich/cobra-extensions/pkg"
-	"github.com/matzefriedrich/cobra-extensions/pkg/abstractions"
+	"github.com/matzefriedrich/cobra-extensions/pkg/commands"
+	"github.com/matzefriedrich/cobra-extensions/pkg/types"
 	"github.com/matzefriedrich/parsley/internal/utils"
 	"github.com/spf13/cobra"
 )
 
 type versionCommand struct {
-	use            abstractions.CommandName `flag:"version" short:"Show the current Parsley CLI version"`
-	CheckForUpdate bool                     `flag:"check-update" usage:"Checks for available updates and prints the update command"`
+	use            types.CommandName `flag:"version" short:"Show the current Parsley CLI version"`
+	CheckForUpdate bool              `flag:"check-update" usage:"Checks for available updates and prints the update command"`
 	httpClient     utils.HttpClient
 }
 
@@ -54,12 +54,12 @@ func (v *versionCommand) Execute() {
 	}
 }
 
-var _ pkg.TypedCommand = (*versionCommand)(nil)
+var _ types.TypedCommand = (*versionCommand)(nil)
 
 // NewVersionCommand creates a new cobra.Command that displays the current version of the Parsley CLI and checks for updates.
 func NewVersionCommand(httpClient utils.HttpClient) *cobra.Command {
 	command := &versionCommand{
 		httpClient: httpClient,
 	}
-	return pkg.CreateTypedCommand(command)
+	return commands.CreateTypedCommand(command)
 }


### PR DESCRIPTION
Upgraded the `cobra-extensions` library to version 0.3.0. Adjusted the import paths in the internal commands to reflect the new package structure introduced in the updated library.