### PR TITLE
feature/factory-funcs

### DIFF
--- a/internal/tests/features/factory_test.go
+++ b/internal/tests/features/factory_test.go
@@ -1,0 +1,95 @@
+package features
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/features"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_register_factory_for_type_returns_transient_instance(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	registry.Register(newGreeterWithState, types.LifetimeTransient)
+	_ = features.RegisterFactory[Greeter](registry, types.LifetimeSingleton)
+
+	resolver := resolving.NewResolver(registry)
+
+	ctx := context.Background()
+
+	// Act
+	factory, _ := resolving.ResolveRequiredService[features.FactoryFunc[Greeter]](resolver, ctx)
+
+	scopedContext := resolving.NewScopedContext(ctx)
+	actual, _ := factory(scopedContext)
+	other, _ := factory(scopedContext)
+
+	// Assert
+	assert.NotNil(t, actual)
+	assert.NotNil(t, other)
+
+	actualValue := reflect.ValueOf(actual)
+	actualInstancePointer := actualValue.Pointer()
+
+	otherValue := reflect.ValueOf(other)
+	otherInstancePointer := otherValue.Pointer()
+
+	assert.NotEqual(t, actualInstancePointer, otherInstancePointer)
+}
+
+func Test_register_factory_for_type_returns_same_instance_per_scope(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	registry.Register(newGreeterWithState, types.LifetimeScoped)
+	_ = features.RegisterFactory[Greeter](registry, types.LifetimeSingleton)
+
+	resolver := resolving.NewResolver(registry)
+
+	ctx := context.Background()
+
+	// Act
+	factory, _ := resolving.ResolveRequiredService[features.FactoryFunc[Greeter]](resolver, ctx)
+
+	scopedContext := resolving.NewScopedContext(ctx)
+	actual, _ := factory(scopedContext)
+	other, _ := factory(scopedContext)
+
+	// Assert
+	assert.NotNil(t, actual)
+	assert.NotNil(t, other)
+
+	actualValue := reflect.ValueOf(actual)
+	actualInstancePointer := actualValue.Pointer()
+
+	otherValue := reflect.ValueOf(other)
+	otherInstancePointer := otherValue.Pointer()
+
+	assert.Equal(t, actualInstancePointer, otherInstancePointer)
+}
+
+type statefulGreeter struct {
+	v int
+}
+
+func (g *statefulGreeter) SayNothing() {
+}
+
+func (g *statefulGreeter) SayHello(name string, _ bool) (string, error) {
+	return "Hello " + name, nil
+}
+
+var _ Greeter = &greeter{}
+
+func newGreeterWithState() Greeter {
+	return &statefulGreeter{
+		v: rand.Int(), // needed to work around the Go-compilers optimization (allocation elision and escape analysis)
+	}
+}

--- a/pkg/features/factory.go
+++ b/pkg/features/factory.go
@@ -1,0 +1,31 @@
+package features
+
+import (
+	"context"
+
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+)
+
+// FactoryFunc represents a function that creates an instance of type T using a context for dependency resolution.
+type FactoryFunc[T any] func(ctx context.Context) (T, error)
+
+// RegisterFactory registers a factory function for resolving instances of a specified type with a given lifetime scope.
+func RegisterFactory[T any](registry types.ServiceRegistry, scope types.LifetimeScope) error {
+	f := func(resolver types.Resolver) FactoryFunc[T] {
+		return resolverFunc[T](resolver)
+	}
+	return registry.Register(f, scope)
+}
+
+// resolverFunc creates and returns a FactoryFunc that resolves an instance of type T using the provided resolver.
+func resolverFunc[T any](resolver types.Resolver) FactoryFunc[T] {
+	return func(ctx context.Context) (T, error) {
+		instance, err := resolving.ResolveRequiredService[T](resolver, ctx)
+		if err != nil {
+			var nilInstance T
+			return nilInstance, err
+		}
+		return instance, nil
+	}
+}


### PR DESCRIPTION
Adds the `RegisterFactory[T any](registry types.ServiceRegistry, scope types.LifetimeScope) error` function to the `features` sub-package. It can be used to register generic factory functions for dynamic dependency resolution.