### PR TITLE
feature/extend-proxies-module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.junie/
 .vscode/
 
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.0] - 2026-04-20
+
+This version improves the proxy generation and method interception functionality.
+
+### Added
+
+* Extended `ParameterInfo` and `ReturnValueInfo` types; added `Name()`, `Value()`, `ParameterType()`, and `ValueType()` methods to allow interceptors to access parameter metadata.
+
+### Fixed
+
+* Fixed a bug where type information for `nil` parameters or return values was lost during method interception by using interface-based reflection in `ProxyBase`.
+
+
 ## [v1.3.3] - 2026-04-16
 
 * Bumps `golang.org/x/mod` from 0.33.0 to 0.35.0

--- a/internal/generator/type_model_functions.go
+++ b/internal/generator/type_model_functions.go
@@ -13,6 +13,7 @@ func RegisterTypeModelFunctions(generator GenericCodeGenerator) error {
 		NamedFunc("FormatType", FormatType),
 		NamedFunc("FormattedCallParameters", FormattedCallParameters),
 		NamedFunc("FormattedParameters", FormattedParameters),
+		NamedFunc("FormattedResultNames", FormattedResultNames),
 		NamedFunc("FormattedResultParameters", FormattedResultParameters),
 		NamedFunc("FormattedResultTypes", FormattedResultTypes),
 		NamedFunc("HasResults", HasResults),
@@ -56,6 +57,18 @@ func FormattedResultParameters(m reflection.Method) string {
 	formattedResults := make([]string, len(m.Results))
 	for i, result := range m.Results {
 		formattedResults[i] = fmt.Sprintf("%s", result.Name)
+	}
+	return strings.Join(formattedResults, ", ")
+}
+
+// FormattedResultNames formats the result parameter names as a comma-separated string of quoted names.
+func FormattedResultNames(m reflection.Method) string {
+	if m.Results == nil {
+		return ""
+	}
+	formattedResults := make([]string, len(m.Results))
+	for i, result := range m.Results {
+		formattedResults[i] = fmt.Sprintf("%q", result.Name)
 	}
 	return strings.Join(formattedResults, ", ")
 }

--- a/internal/generator/type_model_functions.go
+++ b/internal/generator/type_model_functions.go
@@ -12,13 +12,20 @@ func RegisterTypeModelFunctions(generator GenericCodeGenerator) error {
 	return generator.AddTemplateFunc(
 		NamedFunc("FormatType", FormatType),
 		NamedFunc("FormattedCallParameters", FormattedCallParameters),
+		NamedFunc("FormattedParameterNames", FormattedParameterNames),
 		NamedFunc("FormattedParameters", FormattedParameters),
 		NamedFunc("FormattedResultNames", FormattedResultNames),
 		NamedFunc("FormattedResultParameters", FormattedResultParameters),
 		NamedFunc("FormattedResultTypes", FormattedResultTypes),
+		NamedFunc("HasParameters", HasParameters),
 		NamedFunc("HasResults", HasResults),
 		NamedFunc("Signature", Signature),
 	)
+}
+
+// HasParameters checks if the given reflection.Method has any parameters.
+func HasParameters(m reflection.Method) bool {
+	return len(m.Parameters) > 0
 }
 
 // HasResults checks if the given reflection.Method has any result parameters.
@@ -45,6 +52,18 @@ func FormattedCallParameters(m reflection.Method) string {
 			name = fmt.Sprintf("%s...", name)
 		}
 		formattedParameters[i] = fmt.Sprintf("%s", name)
+	}
+	return strings.Join(formattedParameters, ", ")
+}
+
+// FormattedParameterNames formats the parameter names as a comma-separated string of quoted names.
+func FormattedParameterNames(m reflection.Method) string {
+	if m.Parameters == nil {
+		return ""
+	}
+	formattedParameters := make([]string, len(m.Parameters))
+	for i, parameter := range m.Parameters {
+		formattedParameters[i] = fmt.Sprintf("%q", parameter.Name)
 	}
 	return strings.Join(formattedParameters, ", ")
 }

--- a/internal/reflection/type_visitor.go
+++ b/internal/reflection/type_visitor.go
@@ -48,12 +48,24 @@ func CollectResultFieldsFor(funcType *ast.FuncType) []Parameter {
 	if funcType.Results == nil {
 		return parameters
 	}
-	for index, field := range funcType.Results.List {
+	resultIndex := 0
+	for _, field := range funcType.Results.List {
 		typeInfo := getFieldTypeInfo(field)
-		parameters = append(parameters, Parameter{
-			Name: fmt.Sprintf("result%d", index),
-			Type: typeInfo,
-		})
+		if len(field.Names) == 0 {
+			parameters = append(parameters, Parameter{
+				Name: fmt.Sprintf("result%d", resultIndex),
+				Type: typeInfo,
+			})
+			resultIndex++
+		} else {
+			for _, name := range field.Names {
+				parameters = append(parameters, Parameter{
+					Name: name.Name,
+					Type: typeInfo,
+				})
+				resultIndex++
+			}
+		}
 	}
 	return parameters
 }

--- a/internal/reflection/type_visitor.go
+++ b/internal/reflection/type_visitor.go
@@ -2,8 +2,9 @@ package reflection
 
 import (
 	"fmt"
-	"github.com/matzefriedrich/parsley/internal"
 	"go/ast"
+
+	"github.com/matzefriedrich/parsley/internal"
 )
 
 type interfaceMethodsCollector struct {
@@ -119,7 +120,7 @@ func getFieldTypeInfo(param *ast.Field) *ParameterType {
 	}
 
 	last := typeStack.Pop()
-	result := &last
+	result := new(last)
 	for typeStack.IsEmpty() == false {
 		parameterType := typeStack.Pop()
 		parameterType.Next = result

--- a/internal/reflection/types.go
+++ b/internal/reflection/types.go
@@ -75,7 +75,7 @@ type Comment struct {
 	Text string
 }
 
-// Model The generator root model type.
+// Model is the generator root model type.
 type Model struct {
 	Comments    []Comment
 	Interfaces  []Interface

--- a/internal/templates/generator/method_interception.gotmpl
+++ b/internal/templates/generator/method_interception.gotmpl
@@ -37,11 +37,12 @@ func New{{ $proxyTypeName | asPublic }}(target {{$interface.Name}}, interceptors
 func (p *{{$proxyTypeName}}) {{$method.Name}}({{$method | FormattedParameters}}) {{$method | FormattedResultTypes}} {
 
     const methodName = "{{$method.Name}}"
-    parameters := map[string]interface{}{ {{range
-        $p, $parameter := .Parameters}}
-		"{{$parameter.Name}}": {{$parameter.Name}},
-{{end}}	}
-
+    parameters := map[string]interface{}{
+{{ range $p, $parameter := .Parameters -}}
+        "{{ $parameter.Name }}": {{ $parameter.Name }},
+{{ end }}
+	}
+	
 	callContext := features.NewMethodCallContext(methodName, parameters)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {

--- a/internal/templates/generator/method_interception.gotmpl
+++ b/internal/templates/generator/method_interception.gotmpl
@@ -42,8 +42,14 @@ func (p *{{$proxyTypeName}}) {{$method.Name}}({{$method | FormattedParameters}})
         "{{ $parameter.Name }}": {{ $parameter.Name }},
 {{ end }}
 	}
+
+	resultNames := []string{
+{{ range $r, $result := .Results -}}
+    "{{$result.Name}}",
+{{ end }}
+    }
 	
-	callContext := features.NewMethodCallContext(methodName, parameters)
+	callContext := features.NewMethodCallContext(methodName, parameters, resultNames...)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {
 	    p.InvokeExitMethodInterceptors(callContext)

--- a/internal/templates/generator/method_interception.gotmpl
+++ b/internal/templates/generator/method_interception.gotmpl
@@ -40,16 +40,13 @@ func (p *{{$proxyTypeName}}) {{$method.Name}}({{$method | FormattedParameters}})
     parameters := map[string]interface{}{
 {{ range $p, $parameter := .Parameters -}}
         "{{ $parameter.Name }}": {{ $parameter.Name }},
-{{ end }}
+{{ end -}}
 	}
 
-	resultNames := []string{
-{{ range $r, $result := .Results -}}
-    "{{$result.Name}}",
-{{ end }}
-    }
-	
-	callContext := features.NewMethodCallContext(methodName, parameters, resultNames...)
+	parameterNames := []string{ {{ $method | FormattedParameterNames }} }
+	resultNames := []string{ {{ $method | FormattedResultNames }} }
+
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters, resultNames...)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {
 	    p.InvokeExitMethodInterceptors(callContext)

--- a/internal/tests/features/proxies_test.go
+++ b/internal/tests/features/proxies_test.go
@@ -1,0 +1,277 @@
+package features
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/features"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_NewInterceptorBase_verify_name_and_position_accessors(t *testing.T) {
+	// Arrange
+	name := "test-interceptor"
+	position := 10
+
+	// Act
+	base := features.NewInterceptorBase(name, position)
+
+	// Assert
+	assert.Equal(t, name, base.Name())
+	assert.Equal(t, position, base.Position())
+}
+
+func Test_NewReturnValueInfo_verify_accessors(t *testing.T) {
+	// Arrange
+	name := "result0"
+	value := "world"
+	valueType := reflect.TypeOf(value)
+
+	// Act
+	sut := features.NewReturnValueInfo(name, value, valueType)
+
+	// Assert
+	assert.Equal(t, name, sut.Name())
+	assert.Equal(t, value, sut.Value())
+	assert.Equal(t, valueType, sut.ValueType())
+
+	s := sut.String()
+	assert.Contains(t, s, name)
+	assert.Contains(t, s, valueType.String())
+	assert.Contains(t, s, value)
+}
+
+func Test_ReturnValueInfo_nil_value_does_not_panic(t *testing.T) {
+	// Arrange
+	name := "result0"
+	var value interface{} = nil
+	errorType := reflect.TypeOf((*error)(nil)).Elem()
+
+	// Act
+	actual := features.NewReturnValueInfo(name, value, errorType)
+
+	// Assert
+	assert.Equal(t, name, actual.Name())
+	assert.Nil(t, actual.Value())
+	assert.Equal(t, errorType, actual.ValueType())
+
+	s := actual.String()
+	assert.Contains(t, s, name)
+	assert.Contains(t, s, errorType.String())
+	assert.Contains(t, s, "nil")
+}
+
+type captureInterceptor struct {
+	features.InterceptorBase
+	capturedParameters   []features.ParameterInfo
+	capturedReturnValues []features.ReturnValueInfo
+	capturedError        error
+}
+
+func (c *captureInterceptor) Enter(_ any, _ string, parameters []features.ParameterInfo) {
+	c.capturedParameters = parameters
+}
+
+func (c *captureInterceptor) Exit(_ any, _ string, returnValues []features.ReturnValueInfo) {
+	c.capturedReturnValues = returnValues
+}
+
+func (c *captureInterceptor) OnError(_ any, _ string, err error) {
+	c.capturedError = err
+}
+
+func newCaptureInterceptor() *captureInterceptor {
+	return &captureInterceptor{
+		InterceptorBase: features.NewInterceptorBase("capture", 0),
+	}
+}
+
+func Test_ProxyBase_Interception(t *testing.T) {
+	// Arrange
+	target := &greeter{}
+	interceptor := newCaptureInterceptor()
+	sut := features.NewProxyBase[Greeter](target, []features.MethodInterceptor{interceptor})
+
+	methodName := "SayHello"
+	parameterNames := []string{"name", "polite"}
+	parameters := map[string]interface{}{
+		"name":   "John",
+		"polite": true,
+	}
+	resultNames := []string{"result0", "result1"}
+
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters, resultNames...)
+
+	// Act
+	sut.InvokeEnterMethodInterceptors(callContext)
+
+	// Note: Simulate target call
+	res0, res1 := target.SayHello("John", true)
+
+	sut.InvokeMethodErrorInterceptors(callContext, res0, res1)
+	sut.InvokeExitMethodInterceptors(callContext)
+
+	// Assert
+	assert.Len(t, interceptor.capturedParameters, 2)
+
+	firstCapturedParameter := interceptor.capturedParameters[0]
+	assert.Equal(t, "name", firstCapturedParameter.Name())
+	assert.Equal(t, "John", firstCapturedParameter.Value())
+
+	secondCapturedParameter := interceptor.capturedParameters[1]
+	assert.Equal(t, "polite", secondCapturedParameter.Name())
+	assert.Equal(t, true, secondCapturedParameter.Value())
+
+	s := firstCapturedParameter.String()
+	assert.Contains(t, s, "name")
+	assert.Contains(t, s, "string")
+	assert.Contains(t, s, "John")
+
+	assert.Len(t, interceptor.capturedReturnValues, 2)
+
+	firstReturnValue := interceptor.capturedReturnValues[0]
+	assert.Equal(t, "result0", firstReturnValue.Name())
+	assert.Equal(t, "Hello John", firstReturnValue.Value())
+
+	secondReturnValue := interceptor.capturedReturnValues[1]
+	assert.Equal(t, "result1", secondReturnValue.Name())
+	assert.Nil(t, secondReturnValue.Value())
+}
+
+func Test_ProxyBase_InvokeMethodErrorInterceptors_invokes_OnError(t *testing.T) {
+	// Arrange
+	target := &johnGreeter{} // From register_proxy_error_test.go
+	interceptor := newCaptureInterceptor()
+	sut := features.NewProxyBase[Greeter](target, []features.MethodInterceptor{interceptor})
+
+	methodName := "SayHello"
+	parameterNames := []string{"name", "polite"}
+	parameters := map[string]interface{}{
+		"name":   "Jane",
+		"polite": false,
+	}
+	resultNames := []string{"result0", "result1"}
+
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters, resultNames...)
+
+	// Act
+	res0, res1 := target.SayHello("Jane", false) // Note: simulate target call
+	sut.InvokeMethodErrorInterceptors(callContext, res0, res1)
+
+	// Assert
+	assert.NotNil(t, interceptor.capturedError)
+	assert.Equal(t, "name is not John", interceptor.capturedError.Error())
+
+	// Test proxyError behavior (Unwrap and Is)
+	unwrapped := errors.Unwrap(interceptor.capturedError)
+	assert.NotNil(t, unwrapped)
+	assert.Equal(t, "name is not John", unwrapped.Error())
+
+	assert.True(t, errors.Is(interceptor.capturedError, errors.New("name is not John")))
+}
+
+func Test_ProxyBase_InvokeEnterMethodInterceptors_reflects_type_for_nil_parameter_value(t *testing.T) {
+	// Arrange
+	target := &nilParamGreeter{}
+	interceptor := newCaptureInterceptor()
+	sut := features.NewProxyBase[NilParamRepro](target, []features.MethodInterceptor{interceptor})
+
+	methodName := "SaySomething"
+	parameterNames := []string{"err"}
+	parameters := map[string]interface{}{
+		"err": nil,
+	}
+
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters)
+
+	// Act
+	sut.InvokeEnterMethodInterceptors(callContext)
+
+	// Assert
+	assert.Len(t, interceptor.capturedParameters, 1)
+
+	firstCapturedParameter := interceptor.capturedParameters[0]
+	assert.Equal(t, "err", firstCapturedParameter.Name())
+	assert.Nil(t, firstCapturedParameter.Value())
+
+	expectedParameterType := reflect.TypeOf((*error)(nil)).Elem()
+	assert.Equal(t, expectedParameterType, firstCapturedParameter.ParameterType())
+}
+
+type nilParamGreeter struct{}
+
+func (n *nilParamGreeter) SaySomething(_ error) {}
+
+func Test_ProxyBase_InvokeEnterMethodInterceptors_invokes_interceptors_in_correct_order(t *testing.T) {
+	// Arrange
+	target := &greeter{}
+	order := make([]string, 0)
+	i1 := &orderInterceptor{InterceptorBase: features.NewInterceptorBase("i1", 10), order: &order}
+	i2 := &orderInterceptor{InterceptorBase: features.NewInterceptorBase("i2", 5), order: &order}
+	i3 := &orderInterceptor{InterceptorBase: features.NewInterceptorBase("i3", 15), order: &order}
+
+	sut := features.NewProxyBase[Greeter](target, []features.MethodInterceptor{i1, i2, i3})
+	callContext := features.NewMethodCallContext("SayNothing", []string{}, map[string]interface{}{})
+
+	// Act
+	sut.InvokeEnterMethodInterceptors(callContext)
+
+	// Assert
+	assert.Equal(t, []string{"i2", "i1", "i3"}, order)
+}
+
+type orderInterceptor struct {
+	features.InterceptorBase
+	order *[]string
+}
+
+func (o *orderInterceptor) Enter(_ any, _ string, _ []features.ParameterInfo) {
+	*o.order = append(*o.order, o.Name())
+}
+
+func (o *orderInterceptor) Exit(_ any, _ string, _ []features.ReturnValueInfo) {}
+func (o *orderInterceptor) OnError(_ any, _ string, _ error)                   {}
+
+func Test_ProxyBase_InvokeEnterMethodInterceptors_does_not_panic_if_method_not_found(t *testing.T) {
+	// Arrange
+	target := &greeter{}
+	interceptor := newCaptureInterceptor()
+	sut := features.NewProxyBase[Greeter](target, []features.MethodInterceptor{interceptor})
+
+	callContext := features.NewMethodCallContext("NonExistentMethod", []string{}, map[string]interface{}{})
+
+	// Act
+	sut.InvokeEnterMethodInterceptors(callContext)
+	sut.InvokeMethodErrorInterceptors(callContext, "some result")
+
+	// Assert
+	assert.Empty(t, interceptor.capturedParameters)
+}
+
+func Test_ProxyBase_NewMethodCallContext_uses_default_return_parameter_names_if_not_given(t *testing.T) {
+	// Arrange
+	target := &greeter{}
+	interceptor := newCaptureInterceptor()
+	sut := features.NewProxyBase[Greeter](target, []features.MethodInterceptor{interceptor})
+
+	methodName := "SayHello"
+	parameterNames := []string{"name", "polite"}
+	parameters := map[string]interface{}{"name": "John", "polite": true}
+
+	// Note: create context with default result names
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters)
+
+	// Act
+	sut.InvokeMethodErrorInterceptors(callContext, "Hello", nil)
+	sut.InvokeExitMethodInterceptors(callContext)
+
+	// Assert
+	assert.Len(t, interceptor.capturedReturnValues, 2)
+
+	firstCapturedReturnValue := interceptor.capturedReturnValues[0]
+	assert.Equal(t, "result0", firstCapturedReturnValue.Name())
+
+	secondCapturedReturnValue := interceptor.capturedReturnValues[1]
+	assert.Equal(t, "result1", secondCapturedReturnValue.Name())
+}

--- a/internal/tests/features/register_proxy_test.go
+++ b/internal/tests/features/register_proxy_test.go
@@ -17,10 +17,10 @@ func Test_Register_generated_proxy_type(t *testing.T) {
 	collector := &callCollector{methods: make([]string, 0)}
 
 	registry := registration.NewServiceRegistry()
-	registry.Register(newMethodCallInterceptor(collector), types.LifetimeSingleton)
-	registry.Register(NewGreeterProxyImpl, types.LifetimeTransient)
-	registry.Register(newGreeter, types.LifetimeTransient)
-	features.RegisterList[features.MethodInterceptor](ctx, registry)
+	_ = registry.Register(newMethodCallInterceptor(collector), types.LifetimeSingleton)
+	_ = registry.Register(NewGreeterProxyImpl, types.LifetimeTransient)
+	_ = registry.Register(newGreeter, types.LifetimeTransient)
+	_ = features.RegisterList[features.MethodInterceptor](ctx, registry)
 
 	resolver := resolving.NewResolver(registry)
 	resolverContext := resolving.NewScopedContext(ctx)

--- a/internal/tests/features/register_proxy_test.go
+++ b/internal/tests/features/register_proxy_test.go
@@ -66,7 +66,7 @@ func (m methodCallInterceptor) Enter(_ any, methodName string, parameters []feat
 func (m methodCallInterceptor) Exit(_ any, methodName string, returnValues []features.ReturnValueInfo) {
 	fmt.Println("Exit method: ", methodName)
 	for _, value := range returnValues {
-		fmt.Printf("\tResult: %s\n", value)
+		fmt.Printf("\tResult: %v\n", value)
 	}
 }
 

--- a/internal/tests/features/reproduce_nil_param_test.go
+++ b/internal/tests/features/reproduce_nil_param_test.go
@@ -1,0 +1,83 @@
+package features
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/features"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+)
+
+func Test_Proxy_reflect_parameter_type_nil_value(t *testing.T) {
+
+	// Arrange
+	ctx := t.Context()
+	collector := &nilParamCollector{}
+
+	registry := registration.NewServiceRegistry()
+	_ = registry.Register(newNilParamInterceptor(collector), types.LifetimeSingleton)
+	_ = registry.Register(NewNilParamReproProxyImpl, types.LifetimeTransient)
+	_ = registry.Register(newNilParamReproImpl, types.LifetimeTransient)
+	_ = features.RegisterList[features.MethodInterceptor](ctx, registry)
+
+	resolver := resolving.NewResolver(registry)
+	resolverContext := resolving.NewScopedContext(ctx)
+
+	// Act
+	proxy, _ := resolving.ResolveRequiredService[NilParamReproProxy](resolverContext, resolver)
+	proxy.SaySomething(nil)
+
+	// Assert
+	if collector.paramType == nil {
+		t.Error("Parameter type was lost (nil) for nil parameter value")
+	} else {
+		fmt.Printf("Parameter type for nil error: %v\n", collector.paramType)
+		if collector.paramType.String() != "error" {
+			t.Errorf("Expected parameter type 'error', got '%v'", collector.paramType)
+		}
+	}
+}
+
+type nilParamCollector struct {
+	paramType reflect.Type
+}
+
+type nilParamInterceptor struct {
+	features.InterceptorBase
+	collector *nilParamCollector
+}
+
+func (m nilParamInterceptor) Enter(_ any, methodName string, parameters []features.ParameterInfo) {
+	if methodName == "SaySomething" {
+		for _, p := range parameters {
+			if p.Name() == "err" {
+				m.collector.paramType = p.ParameterType()
+			}
+		}
+	}
+}
+
+func (m nilParamInterceptor) Exit(_ any, _ string, _ []features.ReturnValueInfo) {}
+func (m nilParamInterceptor) OnError(_ any, _ string, _ error)                   {}
+
+var _ features.MethodInterceptor = &nilParamInterceptor{}
+
+func newNilParamInterceptor(collector *nilParamCollector) func() features.MethodInterceptor {
+	return func() features.MethodInterceptor {
+		return &nilParamInterceptor{
+			InterceptorBase: features.NewInterceptorBase("nil-param-interceptor", 0),
+			collector:       collector,
+		}
+	}
+}
+
+type nilParamReproImpl struct{}
+
+func (n *nilParamReproImpl) SaySomething(err error) {}
+
+func newNilParamReproImpl() NilParamRepro {
+	return &nilParamReproImpl{}
+}

--- a/internal/tests/features/types.go
+++ b/internal/tests/features/types.go
@@ -8,3 +8,7 @@ type Greeter interface {
 	SayHello(name string, polite bool) (string, error)
 	SayNothing()
 }
+
+type NilParamRepro interface {
+	SaySomething(err error)
+}

--- a/internal/tests/features/types.proxy.g.go
+++ b/internal/tests/features/types.proxy.g.go
@@ -36,12 +36,10 @@ func (p *greeterProxyImpl) SayHello(name string, polite bool) (string, error) {
 		"polite": polite,
 	}
 
-	resultNames := []string{
-		"result0",
-		"result1",
-	}
+	parameterNames := []string{"name", "polite"}
+	resultNames := []string{"result0", "result1"}
 
-	callContext := features.NewMethodCallContext(methodName, parameters, resultNames...)
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters, resultNames...)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {
 		p.InvokeExitMethodInterceptors(callContext)
@@ -57,9 +55,10 @@ func (p *greeterProxyImpl) SayNothing() {
 	const methodName = "SayNothing"
 	parameters := map[string]interface{}{}
 
+	parameterNames := []string{}
 	resultNames := []string{}
 
-	callContext := features.NewMethodCallContext(methodName, parameters, resultNames...)
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters, resultNames...)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {
 		p.InvokeExitMethodInterceptors(callContext)

--- a/internal/tests/features/types.proxy.g.go
+++ b/internal/tests/features/types.proxy.g.go
@@ -28,6 +28,25 @@ func NewGreeterProxyImpl(target Greeter, interceptors []features.MethodIntercept
 	}
 }
 
+// nilParamReproProxyImpl A generated proxy service type for NilParamRepro objects.
+type nilParamReproProxyImpl struct {
+	features.ProxyBase
+	target NilParamRepro
+}
+
+// NilParamReproProxy An interface type for NilParamRepro objects. Parsley needs this to distinguish the proxy from the actual implementation.
+type NilParamReproProxy interface {
+	NilParamRepro
+}
+
+// NewNilParamReproProxyImpl Creates a new NilParamReproProxy object. Register this constructor method with the registry.
+func NewNilParamReproProxyImpl(target NilParamRepro, interceptors []features.MethodInterceptor) NilParamReproProxy {
+	return &nilParamReproProxyImpl{
+		ProxyBase: features.NewProxyBase(target, interceptors),
+		target:    target,
+	}
+}
+
 func (p *greeterProxyImpl) SayHello(name string, polite bool) (string, error) {
 
 	const methodName = "SayHello"
@@ -67,4 +86,24 @@ func (p *greeterProxyImpl) SayNothing() {
 	p.target.SayNothing()
 }
 
+func (p *nilParamReproProxyImpl) SaySomething(err error) {
+
+	const methodName = "SaySomething"
+	parameters := map[string]interface{}{
+		"err": err,
+	}
+
+	parameterNames := []string{"err"}
+	resultNames := []string{}
+
+	callContext := features.NewMethodCallContext(methodName, parameterNames, parameters, resultNames...)
+	p.InvokeEnterMethodInterceptors(callContext)
+	defer func() {
+		p.InvokeExitMethodInterceptors(callContext)
+	}()
+
+	p.target.SaySomething(err)
+}
+
 var _ Greeter = &greeterProxyImpl{}
+var _ NilParamRepro = &nilParamReproProxyImpl{}

--- a/internal/tests/features/types.proxy.g.go
+++ b/internal/tests/features/types.proxy.g.go
@@ -32,8 +32,7 @@ func (p *greeterProxyImpl) SayHello(name string, polite bool) (string, error) {
 
 	const methodName = "SayHello"
 	parameters := map[string]interface{}{
-		"name": name,
-
+		"name":   name,
 		"polite": polite,
 	}
 

--- a/internal/tests/features/types.proxy.g.go
+++ b/internal/tests/features/types.proxy.g.go
@@ -36,7 +36,12 @@ func (p *greeterProxyImpl) SayHello(name string, polite bool) (string, error) {
 		"polite": polite,
 	}
 
-	callContext := features.NewMethodCallContext(methodName, parameters)
+	resultNames := []string{
+		"result0",
+		"result1",
+	}
+
+	callContext := features.NewMethodCallContext(methodName, parameters, resultNames...)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {
 		p.InvokeExitMethodInterceptors(callContext)
@@ -52,7 +57,9 @@ func (p *greeterProxyImpl) SayNothing() {
 	const methodName = "SayNothing"
 	parameters := map[string]interface{}{}
 
-	callContext := features.NewMethodCallContext(methodName, parameters)
+	resultNames := []string{}
+
+	callContext := features.NewMethodCallContext(methodName, parameters, resultNames...)
 	p.InvokeEnterMethodInterceptors(callContext)
 	defer func() {
 		p.InvokeExitMethodInterceptors(callContext)

--- a/internal/tests/generator/type_model_functions_test.go
+++ b/internal/tests/generator/type_model_functions_test.go
@@ -1,11 +1,12 @@
 package generator
 
 import (
+	"testing"
+
 	"github.com/matzefriedrich/parsley/internal/generator"
 	"github.com/matzefriedrich/parsley/internal/reflection"
 	"github.com/matzefriedrich/parsley/internal/tests/mocks"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_RegisterTypeModelFunctions_ensure_expected_methods(t *testing.T) {
@@ -14,9 +15,12 @@ func Test_RegisterTypeModelFunctions_ensure_expected_methods(t *testing.T) {
 	expectedFunctionRegistrations := []string{
 		"FormatType",
 		"FormattedCallParameters",
+		"FormattedParameterNames",
 		"FormattedParameters",
+		"FormattedResultNames",
 		"FormattedResultParameters",
 		"FormattedResultTypes",
+		"HasParameters",
 		"HasResults",
 		"Signature",
 	}
@@ -105,6 +109,35 @@ func Test_FormatType_array_pointer_type(t *testing.T) {
 	assert.Equal(t, "[]*Arg", actual)
 }
 
+func Test_FormatType_selector_name(t *testing.T) {
+	// Arrange
+	p := reflection.Parameter{
+		Name: "p",
+		Type: &reflection.ParameterType{
+			SelectorName: "context",
+			Name:         "Context",
+		},
+	}
+	// Act
+	actual := generator.FormatType(p)
+	// Assert
+	assert.Equal(t, "context.Context", actual)
+}
+
+func Test_FormatType_interface_type(t *testing.T) {
+	// Arrange
+	p := reflection.Parameter{
+		Name: "p",
+		Type: &reflection.ParameterType{
+			IsInterface: true,
+		},
+	}
+	// Act
+	actual := generator.FormatType(p)
+	// Assert
+	assert.Equal(t, "interface{}", actual)
+}
+
 func Test_FormatType_returns_any_if_parameter_type_is_nil(t *testing.T) {
 	// Arrange
 	p := reflection.Parameter{Name: "p", Type: nil}
@@ -167,6 +200,29 @@ func Test_FormattedCallParameters_multiple_parameter(t *testing.T) {
 	actual := generator.FormattedCallParameters(m)
 	// Assert
 	assert.Equal(t, "s, b", actual)
+}
+
+func Test_FormattedParameterNames_multiple_parameters(t *testing.T) {
+	// Arrange
+	m := reflection.Method{
+		Parameters: []reflection.Parameter{
+			{Name: "p1", Type: &reflection.ParameterType{Name: "string"}},
+			{Name: "p2", Type: &reflection.ParameterType{Name: "int"}},
+		},
+	}
+	// Act
+	actual := generator.FormattedParameterNames(m)
+	// Assert
+	assert.Equal(t, `"p1", "p2"`, actual)
+}
+
+func Test_FormattedParameterNames_returns_empty_string_if_Parameters_is_nil(t *testing.T) {
+	// Arrange
+	m := reflection.Method{Parameters: nil}
+	// Act
+	actual := generator.FormattedParameterNames(m)
+	// Assert
+	assert.Equal(t, "", actual)
 }
 
 func Test_FormattedParameters_single_parameter(t *testing.T) {
@@ -264,6 +320,29 @@ func Test_FormattedResultParameters_multiple_parameters(t *testing.T) {
 	assert.Equal(t, "result0, result1", actual)
 }
 
+func Test_FormattedResultNames_multiple_results(t *testing.T) {
+	// Arrange
+	m := reflection.Method{
+		Results: []reflection.Parameter{
+			{Name: "r1", Type: &reflection.ParameterType{Name: "string"}},
+			{Name: "r2", Type: &reflection.ParameterType{Name: "error"}},
+		},
+	}
+	// Act
+	actual := generator.FormattedResultNames(m)
+	// Assert
+	assert.Equal(t, `"r1", "r2"`, actual)
+}
+
+func Test_FormattedResultNames_returns_empty_string_if_Results_is_nil(t *testing.T) {
+	// Arrange
+	m := reflection.Method{Results: nil}
+	// Act
+	actual := generator.FormattedResultNames(m)
+	// Assert
+	assert.Equal(t, "", actual)
+}
+
 func Test_FormattedResultTypes_returns_empty_string_if_Results_is_nil(t *testing.T) {
 	// Arrange
 	m := reflection.Method{Name: "SayHello", Results: nil}
@@ -304,4 +383,73 @@ func Test_Signature_formats_method_name_parameters_and_result_types(t *testing.T
 	actual := generator.Signature(m)
 	// Assert
 	assert.Equal(t, "SayHello(s string) (string, error)", actual)
+}
+
+func Test_Signature_no_results(t *testing.T) {
+	// Arrange
+	m := reflection.Method{
+		Name: "DoSomething",
+		Parameters: []reflection.Parameter{
+			{Name: "p", Type: &reflection.ParameterType{Name: "string"}},
+		},
+	}
+	// Act
+	actual := generator.Signature(m)
+	// Assert
+	assert.Equal(t, "DoSomething(p string)", actual)
+}
+
+func Test_Signature_no_parameters_and_no_results(t *testing.T) {
+	// Arrange
+	m := reflection.Method{
+		Name: "Ping",
+	}
+	// Act
+	actual := generator.Signature(m)
+	// Assert
+	assert.Equal(t, "Ping()", actual)
+}
+
+func Test_HasParameters_returns_true_if_method_has_parameters(t *testing.T) {
+	// Arrange
+	m := reflection.Method{
+		Parameters: []reflection.Parameter{
+			{Name: "p", Type: &reflection.ParameterType{Name: "string"}},
+		},
+	}
+	// Act
+	actual := generator.HasParameters(m)
+	// Assert
+	assert.True(t, actual)
+}
+
+func Test_HasParameters_returns_false_if_method_has_no_parameters(t *testing.T) {
+	// Arrange
+	m := reflection.Method{Parameters: nil}
+	// Act
+	actual := generator.HasParameters(m)
+	// Assert
+	assert.False(t, actual)
+}
+
+func Test_HasResults_returns_true_if_method_has_results(t *testing.T) {
+	// Arrange
+	m := reflection.Method{
+		Results: []reflection.Parameter{
+			{Name: "r", Type: &reflection.ParameterType{Name: "error"}},
+		},
+	}
+	// Act
+	actual := generator.HasResults(m)
+	// Assert
+	assert.True(t, actual)
+}
+
+func Test_HasResults_returns_false_if_method_has_no_results(t *testing.T) {
+	// Arrange
+	m := reflection.Method{Results: nil}
+	// Act
+	actual := generator.HasResults(m)
+	// Assert
+	assert.False(t, actual)
 }

--- a/pkg/features/proxies.go
+++ b/pkg/features/proxies.go
@@ -62,7 +62,22 @@ type ParameterInfo struct {
 
 // String returns a formatted string representation of the ParameterInfo, useful for logging and debugging purposes.
 func (p ParameterInfo) String() string {
-	return fmt.Sprintf("{%s (%s): %s}", p.name, p.parameterType, p.value)
+	return fmt.Sprintf("{%s (%s): %v}", p.name, p.parameterType, p.value)
+}
+
+// Name returns the parameter name.
+func (p ParameterInfo) Name() string {
+	return p.name
+}
+
+// Value returns the value of the parameter.
+func (p ParameterInfo) Value() interface{} {
+	return p.value
+}
+
+// ParameterType retrieves the reflected type of the parameter.
+func (p ParameterInfo) ParameterType() reflect.Type {
+	return p.parameterType
 }
 
 // ReturnValueInfo represents the value and type information of a method's return value, used in method interception.
@@ -71,12 +86,23 @@ type ReturnValueInfo struct {
 	valueType reflect.Type
 }
 
+// Value returns the value stored in the ReturnValueInfo instance.
+func (r ReturnValueInfo) Value() interface{} {
+	return r.value
+}
+
+// ValueType retrieves the return value type.
+func (r ReturnValueInfo) ValueType() reflect.Type {
+	return r.valueType
+}
+
 // String returns a string representation of ReturnValueInfo, formatting the value and its type for debugging purposes.
 func (r ReturnValueInfo) String() string {
+	valueTypeName := r.valueType.String()
 	if r.value != nil {
-		return fmt.Sprintf("{%s: %v}", r.valueType.String(), r.value)
+		return fmt.Sprintf("{%s: %v}", valueTypeName, r.value)
 	}
-	return fmt.Sprintf("{%v}", r.value)
+	return fmt.Sprintf("{%s}: nil", valueTypeName)
 }
 
 // NewMethodCallContext creates a new MethodCallContext instance with the provided method name and parameters.
@@ -89,7 +115,7 @@ func NewMethodCallContext(methodName string, parameters map[string]interface{}) 
 }
 
 // ProxyBase facilitates method interception by allowing the inclusion of multiple interceptors to target method calls.
-// Typically used to monitor, log, or modify behavior of an object's method execution.
+// Typically used to monitor, log, or modify the behavior of an object's method execution.
 type ProxyBase struct {
 	target       any
 	interceptors []MethodInterceptor

--- a/pkg/features/proxies.go
+++ b/pkg/features/proxies.go
@@ -47,10 +47,11 @@ func NewInterceptorBase(name string, position int) InterceptorBase {
 
 // MethodCallContext captures the context of a method call, including method name, parameters, and return values.
 type MethodCallContext struct {
-	methodName   string
-	parameters   map[string]interface{}
-	returnNames  []string
-	returnValues []ReturnValueInfo
+	methodName     string
+	parameterNames []string
+	parameters     map[string]interface{}
+	returnNames    []string
+	returnValues   []ReturnValueInfo
 }
 
 // ParameterInfo represents information about a method parameter, including its value, type, and name.
@@ -122,12 +123,13 @@ func NewReturnValueInfo(name string, value any, valueType reflect.Type) ReturnVa
 }
 
 // NewMethodCallContext creates a new MethodCallContext instance with the provided method name, parameters, and return value names.
-func NewMethodCallContext(methodName string, parameters map[string]interface{}, returnNames ...string) *MethodCallContext {
+func NewMethodCallContext(methodName string, parameterNames []string, parameters map[string]interface{}, returnNames ...string) *MethodCallContext {
 	return &MethodCallContext{
-		methodName:   methodName,
-		parameters:   parameters,
-		returnNames:  returnNames,
-		returnValues: make([]ReturnValueInfo, 0),
+		methodName:     methodName,
+		parameterNames: parameterNames,
+		parameters:     parameters,
+		returnNames:    returnNames,
+		returnValues:   make([]ReturnValueInfo, 0),
 	}
 }
 
@@ -169,15 +171,21 @@ func (p *ProxyBase) InvokeMethodErrorInterceptors(callContext *MethodCallContext
 
 // InvokeEnterMethodInterceptors triggers the Enter method on all registered interceptors before the target method executes.
 func (p *ProxyBase) InvokeEnterMethodInterceptors(callContext *MethodCallContext) {
-	parameters := make([]ParameterInfo, 0, len(callContext.parameters))
-	for name, next := range callContext.parameters {
-		value, parameterType := reflectValueInfo(next)
-		p := ParameterInfo{
+	method, ok := p.targetType.MethodByName(callContext.methodName)
+	if !ok {
+		return
+	}
+
+	parameters := make([]ParameterInfo, 0, len(callContext.parameterNames))
+	for i, name := range callContext.parameterNames {
+		value := callContext.parameters[name]
+		parameterType := method.Type.In(i)
+		pInfo := ParameterInfo{
 			value:         value,
 			parameterType: parameterType,
 			name:          name,
 		}
-		parameters = append(parameters, p)
+		parameters = append(parameters, pInfo)
 	}
 	for _, i := range p.interceptors {
 		i.Enter(p.target, callContext.methodName, parameters)
@@ -206,18 +214,6 @@ func NewProxyBase[T any](target T, interceptors []MethodInterceptor) ProxyBase {
 		targetType:   reflect.TypeOf((*T)(nil)).Elem(),
 		interceptors: sortedInterceptors,
 	}
-}
-
-func reflectValueInfo(next interface{}) (reflect.Value, reflect.Type) {
-	value := reflect.ValueOf(next)
-	var parameterType reflect.Type
-	switch value.Kind() {
-	case reflect.Invalid:
-		parameterType = nil
-	default:
-		parameterType = value.Type()
-	}
-	return value, parameterType
 }
 
 type proxyError struct {

--- a/pkg/features/proxies.go
+++ b/pkg/features/proxies.go
@@ -49,7 +49,8 @@ func NewInterceptorBase(name string, position int) InterceptorBase {
 type MethodCallContext struct {
 	methodName   string
 	parameters   map[string]interface{}
-	returnValues []interface{}
+	returnNames  []string
+	returnValues []ReturnValueInfo
 }
 
 // ParameterInfo represents information about a method parameter, including its value, type, and name.
@@ -82,8 +83,14 @@ func (p ParameterInfo) ParameterType() reflect.Type {
 
 // ReturnValueInfo represents the value and type information of a method's return value, used in method interception.
 type ReturnValueInfo struct {
+	name      string
 	value     interface{}
 	valueType reflect.Type
+}
+
+// Name returns the return value name.
+func (r ReturnValueInfo) Name() string {
+	return r.name
 }
 
 // Value returns the value stored in the ReturnValueInfo instance.
@@ -100,17 +107,27 @@ func (r ReturnValueInfo) ValueType() reflect.Type {
 func (r ReturnValueInfo) String() string {
 	valueTypeName := r.valueType.String()
 	if r.value != nil {
-		return fmt.Sprintf("{%s: %v}", valueTypeName, r.value)
+		return fmt.Sprintf("{%s (%s): %v}", r.name, valueTypeName, r.value)
 	}
-	return fmt.Sprintf("{%s}: nil", valueTypeName)
+	return fmt.Sprintf("{%s (%s)}: nil", r.name, valueTypeName)
 }
 
-// NewMethodCallContext creates a new MethodCallContext instance with the provided method name and parameters.
-func NewMethodCallContext(methodName string, parameters map[string]interface{}) *MethodCallContext {
+// NewReturnValueInfo creates a new ReturnValueInfo object.
+func NewReturnValueInfo(name string, value any, valueType reflect.Type) ReturnValueInfo {
+	return ReturnValueInfo{
+		name:      name,
+		value:     value,
+		valueType: valueType,
+	}
+}
+
+// NewMethodCallContext creates a new MethodCallContext instance with the provided method name, parameters, and return value names.
+func NewMethodCallContext(methodName string, parameters map[string]interface{}, returnNames ...string) *MethodCallContext {
 	return &MethodCallContext{
 		methodName:   methodName,
 		parameters:   parameters,
-		returnValues: make([]interface{}, 0),
+		returnNames:  returnNames,
+		returnValues: make([]ReturnValueInfo, 0),
 	}
 }
 
@@ -118,18 +135,33 @@ func NewMethodCallContext(methodName string, parameters map[string]interface{}) 
 // Typically used to monitor, log, or modify the behavior of an object's method execution.
 type ProxyBase struct {
 	target       any
+	targetType   reflect.Type
 	interceptors []MethodInterceptor
 }
 
 // InvokeMethodErrorInterceptors intercepts the return values of a method, checks for errors, and triggers OnError for registered interceptors.
-func (p *ProxyBase) InvokeMethodErrorInterceptors(callContext *MethodCallContext, returnValues ...interface{}) {
-	for _, next := range returnValues {
-		callContext.returnValues = append(callContext.returnValues, next)
+func (p *ProxyBase) InvokeMethodErrorInterceptors(callContext *MethodCallContext, returnValues ...any) {
+	method, ok := p.targetType.MethodByName(callContext.methodName)
+	if !ok {
+		return
+	}
+
+	for i, next := range returnValues {
+		valueType := method.Type.Out(i)
+		name := fmt.Sprintf("result%d", i)
+		if i < len(callContext.returnNames) {
+			name = callContext.returnNames[i]
+		}
+		info := NewReturnValueInfo(name, next, valueType)
+		callContext.returnValues = append(callContext.returnValues, info)
+		if next == nil {
+			continue
+		}
 		err, ok := next.(error)
 		if ok {
 			wrapped := &proxyError{err: err}
-			for _, i := range p.interceptors {
-				i.OnError(p.target, callContext.methodName, wrapped)
+			for _, interceptor := range p.interceptors {
+				interceptor.OnError(p.target, callContext.methodName, wrapped)
 			}
 		}
 	}
@@ -154,16 +186,8 @@ func (p *ProxyBase) InvokeEnterMethodInterceptors(callContext *MethodCallContext
 
 // InvokeExitMethodInterceptors triggers the Exit method of all registered interceptors after the target method completes.
 func (p *ProxyBase) InvokeExitMethodInterceptors(callContext *MethodCallContext) {
-	returnValues := make([]ReturnValueInfo, 0, len(callContext.returnValues))
-	for _, next := range callContext.returnValues {
-		value, returnType := reflectValueInfo(next)
-		returnValues = append(returnValues, ReturnValueInfo{
-			value:     value,
-			valueType: returnType,
-		})
-	}
 	for _, i := range p.interceptors {
-		i.Exit(p.target, callContext.methodName, returnValues)
+		i.Exit(p.target, callContext.methodName, callContext.returnValues)
 	}
 }
 
@@ -179,6 +203,7 @@ func NewProxyBase[T any](target T, interceptors []MethodInterceptor) ProxyBase {
 	})
 	return ProxyBase{
 		target:       target,
+		targetType:   reflect.TypeOf((*T)(nil)).Elem(),
 		interceptors: sortedInterceptors,
 	}
 }


### PR DESCRIPTION
This PR improves proxy method interception so interceptors can see **parameter names and their declared types**, even when the actual argument value is `nil`. It also extends return-value tracking to preserve **named results** and their reflected types, instead of treating them as anonymous values.

The proxy generator template was updated to pass parameter names into the call context and to build result-name metadata for interceptor hooks. Overall, it makes interception more accurate and fixes the case where a `nil` argument previously caused type information to be lost.