### PR TITLE
Avoid mock generation name collisions across interfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.4.1] - 2026-05-06
+
+### Fixed
+
+* Updated mock generation to include interface-specific prefixes for generated function types and method identifiers, preventing naming collisions when multiple interfaces define methods with the same name. [#78](https://github.com/matzefriedrich/parsley/pull/78)
+
+
 ## [v1.4.0] - 2026-04-23
 
 This version improves the proxy generation and method interception functionality. The proxy generator does now provide a more robust foundation for implementing cross-cutting concerns. The generator effectively removes the tedious work of manually creating proxy types.

--- a/internal/templates/generator/mocks.gotmpl
+++ b/internal/templates/generator/mocks.gotmpl
@@ -28,7 +28,7 @@ import (
 type {{ $mockStructName }} struct {
 	features.MockBase
     {{- range .Methods }}
-    {{ .Name | asPublic }}Func {{ .Name }}Func
+    {{ .Name | asPublic }}Func {{ $interfaceName }}_{{ .Name }}Func
     {{- end }}
 }
 
@@ -36,7 +36,7 @@ type {{ $mockStructName }} struct {
 
 {{- /* Define func types for each method */ -}}
 {{- range .Methods }}
-type {{ .Name }}Func func({{ FormattedParameters . }}) {{ FormattedResultTypes . }}
+type {{ $interfaceName }}_{{ .Name }}Func func({{ FormattedParameters . }}) {{ FormattedResultTypes . }}
 {{- end }}
 
 {{- "\n" -}}
@@ -44,7 +44,7 @@ type {{ .Name }}Func func({{ FormattedParameters . }}) {{ FormattedResultTypes .
 {{- if .Methods }}
 const (
 {{- range .Methods }}
-    Function{{ .Name }} = "{{ .Name }}"
+    Function_{{ $interfaceName }}_{{ .Name }} = "{{ .Name }}"
 {{- end }}
 )
 {{ "" }}
@@ -56,7 +56,7 @@ const (
 {{- /* Define methods for each function, implementing the interface */ -}}
 {{ range .Methods }}
 func (m *{{ $mockStructName }}) {{ .Name }}({{ FormattedParameters . }}) {{ FormattedResultTypes . }} {
-    m.TraceMethodCall(Function{{ .Name }}, {{ FormattedCallParameters . }})
+    m.TraceMethodCall(Function_{{ $interfaceName }}_{{ .Name }}, {{ FormattedCallParameters . }})
     {{- if HasResults . }}
     return m.{{ .Name | asPublic }}Func({{ FormattedCallParameters . }})
     {{- else }}
@@ -91,7 +91,7 @@ func New{{ $interfaceName }}Mock() *{{ $mockStructName }} {
         {{- end }}
     }
     {{- range .Methods }}
-    mock.AddFunction(Function{{.Name}}, "{{ Signature . }}")
+    mock.AddFunction(Function_{{ $interfaceName }}_{{.Name}}, "{{ Signature . }}")
     {{- end }}
 	return mock
 }

--- a/internal/tests/features/mock_test.go
+++ b/internal/tests/features/mock_test.go
@@ -2,9 +2,10 @@ package features
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/matzefriedrich/parsley/pkg/features"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_GreeterMock_SayHello(t *testing.T) {
@@ -26,19 +27,19 @@ func Test_GreeterMock_SayHello(t *testing.T) {
 	assert.Equal(t, "Hi, John", actual)
 
 	// Verify that John has been greeted, regardless of the politeness flag
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesOnce(), features.Exact(expectedName)))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesOnce(), features.Exact(expectedName)))
 
 	// Verify that John has not been greeted non-politely
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesNever(), features.Exact(expectedName), features.Exact(false)))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesNever(), features.Exact(expectedName), features.Exact(false)))
 
 	// Verify that somebody was greeted politely
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesOnce(), features.IsAny(), features.Exact(true)))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesOnce(), features.IsAny(), features.Exact(true)))
 
 	// Verify that Jane was not greeted
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesNever(), features.Exact("Jane")))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesNever(), features.Exact("Jane")))
 
 	// Verify that SayHello was called twice in total, regardless of the call parameters
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesExactly(2)))
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesExactly(2), features.IsAny()))
-	assert.True(t, mock.Verify(FunctionSayHello, features.TimesExactly(2), features.IsAny(), features.IsAny()))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesExactly(2)))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesExactly(2), features.IsAny()))
+	assert.True(t, mock.Verify(Function_Greeter_SayHello, features.TimesExactly(2), features.IsAny(), features.IsAny()))
 }

--- a/internal/tests/features/types.mocks.g.go
+++ b/internal/tests/features/types.mocks.g.go
@@ -10,25 +10,25 @@ import (
 
 type greeterMock struct {
 	features.MockBase
-	SayHelloFunc   SayHelloFunc
-	SayNothingFunc SayNothingFunc
+	SayHelloFunc   Greeter_SayHelloFunc
+	SayNothingFunc Greeter_SayNothingFunc
 }
 
-type SayHelloFunc func(name string, polite bool) (string, error)
-type SayNothingFunc func()
+type Greeter_SayHelloFunc func(name string, polite bool) (string, error)
+type Greeter_SayNothingFunc func()
 
 const (
-	FunctionSayHello   = "SayHello"
-	FunctionSayNothing = "SayNothing"
+	Function_Greeter_SayHello   = "SayHello"
+	Function_Greeter_SayNothing = "SayNothing"
 )
 
 func (m *greeterMock) SayHello(name string, polite bool) (string, error) {
-	m.TraceMethodCall(FunctionSayHello, name, polite)
+	m.TraceMethodCall(Function_Greeter_SayHello, name, polite)
 	return m.SayHelloFunc(name, polite)
 }
 
 func (m *greeterMock) SayNothing() {
-	m.TraceMethodCall(FunctionSayNothing)
+	m.TraceMethodCall(Function_Greeter_SayNothing)
 	m.SayNothingFunc()
 }
 
@@ -45,7 +45,7 @@ func NewGreeterMock() *greeterMock {
 		},
 		SayNothingFunc: func() {},
 	}
-	mock.AddFunction(FunctionSayHello, "SayHello(name string, polite bool) (string, error)")
-	mock.AddFunction(FunctionSayNothing, "SayNothing()")
+	mock.AddFunction(Function_Greeter_SayHello, "SayHello(name string, polite bool) (string, error)")
+	mock.AddFunction(Function_Greeter_SayNothing, "SayNothing()")
 	return mock
 }


### PR DESCRIPTION
### Changes

Updates mock generation to prefix generated function types and method identifiers with the interface name. This prevents naming conflicts when multiple mocked interfaces define methods with the same name, while keeping call tracing and verification behavior intact.