### PR TITLE
Add `RegisterModuleIf` method to conditionally register modules.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+* Added the `RegisterModuleIf(condition bool, modules ...ModuleFunc) error` method to the `ServiceRegistry` interface, allowing for conditional module registration based on runtime requirements or environment settings. [#79](https://github.com/matzefriedrich/parsley/pull/79)
+
+
 ## [v1.4.1] - 2026-05-06
 
 ### Fixed

--- a/internal/tests/registration/registry_test.go
+++ b/internal/tests/registration/registry_test.go
@@ -124,6 +124,44 @@ func Test_Registry_RegisterModule_registers_collection_of_services(t *testing.T)
 	assert.True(t, fooConsumerRegistered)
 }
 
+func Test_Registry_RegisterModuleIf_registers_module_if_condition_is_true(t *testing.T) {
+
+	// Arrange
+	sut := registration.NewServiceRegistry()
+
+	// Act
+	fooModule := func(r types.ServiceRegistry) error {
+		_ = registration.RegisterSingleton(r, newFoo)
+		return nil
+	}
+
+	_ = sut.RegisterModuleIf(true, fooModule)
+
+	fooRegistered := sut.IsRegistered(types.MakeServiceType[Foo]())
+
+	// Assert
+	assert.True(t, fooRegistered)
+}
+
+func Test_Registry_RegisterModuleIf_does_not_register_module_if_condition_is_false(t *testing.T) {
+
+	// Arrange
+	sut := registration.NewServiceRegistry()
+
+	// Act
+	fooModule := func(r types.ServiceRegistry) error {
+		_ = registration.RegisterSingleton(r, newFoo)
+		return nil
+	}
+
+	_ = sut.RegisterModuleIf(false, fooModule)
+
+	fooRegistered := sut.IsRegistered(types.MakeServiceType[Foo]())
+
+	// Assert
+	assert.False(t, fooRegistered)
+}
+
 func Test_Registry_RegisterInstance_registers_singleton_service_from_object(t *testing.T) {
 
 	// Arrange

--- a/pkg/registration/registry.go
+++ b/pkg/registration/registry.go
@@ -58,6 +58,14 @@ func (s *serviceRegistry) RegisterModule(modules ...types.ModuleFunc) error {
 	return nil
 }
 
+// RegisterModuleIf registers one or more modules with the service registry if the provided condition is true.
+func (s *serviceRegistry) RegisterModuleIf(condition bool, modules ...types.ModuleFunc) error {
+	if !condition {
+		return nil
+	}
+	return s.RegisterModule(modules...)
+}
+
 // IsRegistered checks if a service type is registered in the service registry.
 func (s *serviceRegistry) IsRegistered(serviceType types.ServiceType) bool {
 	_, found := s.registrations[serviceType.LookupKey()]

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -72,6 +72,9 @@ type ServiceRegistry interface {
 
 	// RegisterModule registers one or more modules, encapsulated as ModuleFunc, with the service registry. A module is a logical unit of service registrations.
 	RegisterModule(modules ...ModuleFunc) error
+
+	// RegisterModuleIf registers one or more modules with the service registry if the provided condition is true.
+	RegisterModuleIf(condition bool, modules ...ModuleFunc) error
 }
 
 // ModuleFunc defines a function used to register services with the given service registry.


### PR DESCRIPTION
### Changes

* Implements `RegisterModuleIf` in `serviceRegistry` to conditionally register modules based on a boolean condition.
* Updates `types.ServiceRegistry` interface to include `RegisterModuleIf`.
* Adds unit tests to validate `RegisterModuleIf` behavior under true and false conditions.