### PR TITLE
Extend lazy service to support activation with dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Added the `RegisterModuleIf(condition bool, modules ...ModuleFunc) error` method to the `ServiceRegistry` interface, allowing for conditional module registration based on runtime requirements or environment settings. [#79](https://github.com/matzefriedrich/parsley/pull/79)
+* Added the `RegisterModuleIf(condition bool, modules ...ModuleFunc) error` method to the `ServiceRegistry` interface, allowing for conditional module registration based on runtime requirements or environment settings. [#77](https://github.com/matzefriedrich/parsley/issues/77)
+* Enhanced `RegisterLazy[T]` to support activator functions with dependencies, enabling full dependency injection for lazily-activated services. [#80](https://github.com/matzefriedrich/parsley/pull/80)
+
+### Changed
+
+* Updated the `Lazy[T]` interface; the `Value` method now requires a `context.Context` parameter to ensure correct dependency resolution for activator functions. [#80](https://github.com/matzefriedrich/parsley/pull/80)
 
 
 ## [v1.4.1] - 2026-05-06

--- a/internal/tests/features/registry_register_lazy_service_test.go
+++ b/internal/tests/features/registry_register_lazy_service_test.go
@@ -23,8 +23,8 @@ func Test_Registry_register_lazy_service_type_factory(t *testing.T) {
 
 	// Act
 	actual, err := resolving.ResolveRequiredService[features.Lazy[*foo]](ctx, resolver)
-	fooInstance0 := actual.Value()
-	fooInstance1 := actual.Value()
+	fooInstance0 := actual.Value(ctx)
+	fooInstance1 := actual.Value(ctx)
 
 	// Assert
 	assert.NoError(t, err)
@@ -33,5 +33,40 @@ func Test_Registry_register_lazy_service_type_factory(t *testing.T) {
 	assert.NotNil(t, fooInstance1)
 }
 
+func Test_Registry_register_lazy_service_with_dependency(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registration.RegisterSingleton(registry, func() *dependency {
+		return &dependency{Name: "Dependency"}
+	})
+
+	_ = features.RegisterLazy[*service](registry, func(d *dependency) *service {
+		return &service{Dependency: d}
+	}, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	// Act
+	lazyService, err := resolving.ResolveRequiredService[features.Lazy[*service]](ctx, resolver)
+	assert.NoError(t, err)
+
+	serviceInstance := lazyService.Value(ctx)
+
+	// Assert
+	assert.NotNil(t, serviceInstance)
+	assert.NotNil(t, serviceInstance.Dependency)
+	assert.Equal(t, "Dependency", serviceInstance.Dependency.Name)
+}
+
 type foo struct {
+}
+
+type dependency struct {
+	Name string
+}
+
+type service struct {
+	Dependency *dependency
 }

--- a/internal/tests/features/registry_register_lazy_service_test.go
+++ b/internal/tests/features/registry_register_lazy_service_test.go
@@ -23,22 +23,25 @@ func Test_Registry_register_lazy_service_type_factory(t *testing.T) {
 
 	// Act
 	actual, err := resolving.ResolveRequiredService[features.Lazy[*foo]](ctx, resolver)
-	fooInstance0 := actual.Value(ctx)
-	fooInstance1 := actual.Value(ctx)
 
 	// Assert
 	assert.NoError(t, err)
 	assert.NotNil(t, actual)
+
+	fooInstance0 := actual.Value(ctx)
 	assert.NotNil(t, fooInstance0)
+
+	fooInstance1 := actual.Value(ctx)
 	assert.NotNil(t, fooInstance1)
 }
 
 func Test_Registry_register_lazy_service_with_dependency(t *testing.T) {
 
 	// Arrange
+	const expectedName = "Dependency"
 	registry := registration.NewServiceRegistry()
 	_ = registration.RegisterSingleton(registry, func() *dependency {
-		return &dependency{Name: "Dependency"}
+		return &dependency{Name: expectedName}
 	})
 
 	_ = features.RegisterLazy[*service](registry, func(d *dependency) *service {
@@ -57,7 +60,68 @@ func Test_Registry_register_lazy_service_with_dependency(t *testing.T) {
 	// Assert
 	assert.NotNil(t, serviceInstance)
 	assert.NotNil(t, serviceInstance.Dependency)
-	assert.Equal(t, "Dependency", serviceInstance.Dependency.Name)
+	assert.Equal(t, expectedName, serviceInstance.Dependency.Name)
+}
+
+func Test_Lazy_Value_returns_zero_value_on_activation_error(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+
+	// Register a lazy service that depends on something NOT registered
+	activatorFunc := func(d *missingDependency) *serviceWithMissingDependency {
+		return &serviceWithMissingDependency{Dependency: d}
+	}
+	_ = features.RegisterLazy[*serviceWithMissingDependency](registry, activatorFunc, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	// Act
+	lazyService, err := resolving.ResolveRequiredService[features.Lazy[*serviceWithMissingDependency]](ctx, resolver)
+	assert.NoError(t, err)
+
+	// This should fail to activate the underlying service because missingDependency is not registered
+	serviceInstance := lazyService.Value(ctx)
+
+	// Assert
+	assert.Nil(t, serviceInstance)
+}
+
+func Test_Lazy_Value_is_thread_safe(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	counter := 0
+
+	activatorFunc := func() *foo {
+		counter++
+		return &foo{}
+	}
+
+	_ = features.RegisterLazy[*foo](registry, activatorFunc, types.LifetimeTransient)
+
+	resolver := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	lazyService, _ := resolving.ResolveRequiredService[features.Lazy[*foo]](ctx, resolver)
+
+	// Act
+	const iterations = 100
+	done := make(chan bool)
+	for i := 0; i < iterations; i++ {
+		go func() {
+			_ = lazyService.Value(ctx)
+			done <- true
+		}()
+	}
+
+	for i := 0; i < iterations; i++ {
+		<-done
+	}
+
+	// Assert
+	assert.Equal(t, 1, counter)
 }
 
 type foo struct {
@@ -69,4 +133,11 @@ type dependency struct {
 
 type service struct {
 	Dependency *dependency
+}
+
+type missingDependency struct {
+}
+
+type serviceWithMissingDependency struct {
+	Dependency *missingDependency
 }

--- a/pkg/features/lazy_services.go
+++ b/pkg/features/lazy_services.go
@@ -1,20 +1,22 @@
 package features
 
 import (
+	"context"
 	"github.com/matzefriedrich/parsley/internal"
-	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
 	"github.com/matzefriedrich/parsley/pkg/types"
 	"sync"
 )
 
 type lazy[T any] struct {
 	instance      T
-	activatorFunc func() T
+	activatorFunc any
+	resolver      types.Resolver
 	m             sync.RWMutex
 }
 
 // Value returns the instance of the lazy-initialized type, generating it if not already created. Ensures thread-safety.
-func (l *lazy[T]) Value() T {
+func (l *lazy[T]) Value(ctx context.Context) T {
 	l.m.RLock()
 	if internal.IsNil(l.instance) == false {
 		defer l.m.RUnlock()
@@ -23,7 +25,10 @@ func (l *lazy[T]) Value() T {
 		l.m.Lock()
 		defer l.m.Unlock()
 		if internal.IsNil(l.instance) {
-			instance := l.activatorFunc()
+			instance, err := resolving.Activate[T](ctx, l.resolver, l.activatorFunc)
+			if err != nil {
+				return l.instance
+			}
 			l.instance = instance
 		}
 	}
@@ -32,25 +37,17 @@ func (l *lazy[T]) Value() T {
 
 // Lazy represents a type whose value is initialized lazily upon first access, typically to improve performance or manage resources.
 type Lazy[T any] interface {
-	Value() T
+	Value(ctx context.Context) T
 }
 
 var _ Lazy[any] = &lazy[any]{}
 
 // RegisterLazy registers a lazily-activated service in the service registry using the provided activator function.
-func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc func() T, _ types.LifetimeScope) error {
-
-	lazyActivator := newLazyServiceFactory[T](activatorFunc)
-	err := registration.RegisterInstance(registry, lazyActivator)
-	if err != nil {
-		return types.NewRegistryError("failed to register lazy service")
-	}
-
-	return nil
-}
-
-func newLazyServiceFactory[T any](activatorFunc func() T) Lazy[T] {
-	return &lazy[T]{
-		activatorFunc: activatorFunc,
-	}
+func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc any, scope types.LifetimeScope) error {
+	return registry.Register(func(resolver types.Resolver) Lazy[T] {
+		return &lazy[T]{
+			activatorFunc: activatorFunc,
+			resolver:      resolver,
+		}
+	}, scope)
 }

--- a/pkg/features/lazy_services.go
+++ b/pkg/features/lazy_services.go
@@ -2,10 +2,11 @@ package features
 
 import (
 	"context"
+	"sync"
+
 	"github.com/matzefriedrich/parsley/internal"
 	"github.com/matzefriedrich/parsley/pkg/resolving"
 	"github.com/matzefriedrich/parsley/pkg/types"
-	"sync"
 )
 
 type lazy[T any] struct {
@@ -42,7 +43,7 @@ type Lazy[T any] interface {
 
 var _ Lazy[any] = &lazy[any]{}
 
-// RegisterLazy registers a lazily-activated service in the service registry using the provided activator function.
+// RegisterLazy registers a lazily activated service in the service registry using the provided activator function.
 func RegisterLazy[T any](registry types.ServiceRegistry, activatorFunc any, scope types.LifetimeScope) error {
 	return registry.Register(func(resolver types.Resolver) Lazy[T] {
 		return &lazy[T]{


### PR DESCRIPTION
### Changes

* Modified the ` Lazy[T]`  interface in ` pkg/features/lazy_services.go` to change the `Value()` method signature to `Value(ctx context.Context) T`. The implementation of the `lazy[T].Value` method passes the context to `resolving.Activate[T]` when resolving the service instance.
* Updated all unit tests in `internal/tests/features/registry_register_lazy_service_test.go` to pass the appropriate context to `Value()`.