### PR TITLE
Support context.Context and error in activator signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,20 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v1.5.0-alpha1] - 2026-05-07
 
 ### Added
 
 * Added the `RegisterModuleIf(condition bool, modules ...ModuleFunc) error` method to the `ServiceRegistry` interface, allowing for conditional module registration based on runtime requirements or environment settings. [#77](https://github.com/matzefriedrich/parsley/issues/77)
 * Enhanced `RegisterLazy[T]` to support activator functions with dependencies, enabling full dependency injection for lazily-activated services. [#80](https://github.com/matzefriedrich/parsley/pull/80)
+* Support for `context.Context` as the first parameter in activator functions, allowing services to access the resolution context. [#82](https://github.com/matzefriedrich/parsley/pull/82)
+* Support for an optional `error` return value (second position) in activator functions, enabling proper error propagation during service activation. [#82](https://github.com/matzefriedrich/parsley/pull/82)
 
 * Adds `Makefile` to the reposiory [#81](https://github.com/matzefriedrich/parsley/pull/81)
 
 ### Changed
 
 * Updated the `Lazy[T]` interface; the `Value` method now requires a `context.Context` parameter to ensure correct dependency resolution for activator functions. [#80](https://github.com/matzefriedrich/parsley/pull/80)
+* Updated internal activation interfaces `ServiceRegistration.InvokeActivator` and `DependencyInfo.CreateInstance` to accept `context.Context` for propagation to activators. [#82](https://github.com/matzefriedrich/parsley/pull/82)
+* Removes the `context.Context` parameter from `RegisterList`; the registered list activator function does now user the resolver context. * Fixes linter issues and adds new tests [#81](https://github.com/matzefriedrich/parsley/pull/81)
 
+### Fixed
+
+* Fixed test coverage detection for tests located in `internal/tests` by using `-coverpkg=./...` in the `test-coverage` make target. [#82](https://github.com/matzefriedrich/parsley/pull/82)
+* Fixed a bug in `FunctionInfo.String()` where function signature parameters were not correctly formatted in the output string. [#82](https://github.com/matzefriedrich/parsley/pull/82)
 * Fixes linter issues and adds new tests [#81](https://github.com/matzefriedrich/parsley/pull/81)
+
+## [v1.4.2] - 2026-05-06
+
+### Changed
+
+* Bumps application version to 1.4.2 and update `Makefile` to include dynamic versioning via git tags.
 
 
 ## [v1.4.1] - 2026-05-06

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ LDFLAGS=-ldflags "-X github.com/matzefriedrich/parsley/internal/utils.VersionStr
 all: build
 
 # Phony targets
-.PHONY: all build install test lint lint-fix help clean
+.PHONY: all build install test test-coverage lint lint-fix help clean
 
 build: ## Build the parsley-cli binary
 	mkdir -p $(BUILD_DIR)
@@ -21,6 +21,10 @@ install: ## Install the parsley-cli from source
 test: ## Run all tests
 	go test ./...
 
+test-coverage: ## Run tests and compute coverage
+	go test -coverpkg=./... ./... -coverprofile=coverage.out
+	go tool cover -func=coverage.out
+
 lint: ## Run golangci-lint
 	golangci-lint run
 
@@ -29,6 +33,7 @@ lint-fix: ## Run golangci-lint and apply fixes
 
 clean: ## Clean build artifacts
 	rm -rf $(BUILD_DIR)
+	rm -f coverage.out
 
 help: ## Show this help message
 	@echo "Usage: make [target]"

--- a/internal/core/function_info.go
+++ b/internal/core/function_info.go
@@ -1,17 +1,20 @@
 package core
 
 import (
+	"context"
 	"errors"
 	"fmt"
-	"github.com/matzefriedrich/parsley/pkg/types"
 	"reflect"
 	"runtime"
 	"strings"
+
+	"github.com/matzefriedrich/parsley/pkg/types"
 )
 
 const (
 	ErrorNotAFunction                            = "not a function"
 	ErrorReturnTypeHasToHaveExactlyOnReturnValue = "return type has to have exactly one return value"
+	ErrorSecondReturnTypeIsNotErr                = "second return type is not an error type"
 )
 
 var (
@@ -24,6 +27,8 @@ type functionInfo struct {
 	funcType               reflect.Type
 	returnType             types.ServiceType
 	parameters             []types.FunctionParameterInfo
+	hasErrorReturn         bool
+	hasContextParameter    bool
 }
 
 var _ types.FunctionInfo = &functionInfo{}
@@ -53,16 +58,26 @@ func ReflectFunctionInfoFrom(value reflect.Value) (types.FunctionInfo, error) {
 	if funcType.Kind() != reflect.Func {
 		return nil, types.NewReflectionError(ErrorNotAFunction)
 	}
-	rt, err := returnType(funcType)
+	rt, hasError, err := returnType(funcType)
 	if err != nil {
 		return nil, err
 	}
 	parameters := parameterInfos(funcType)
+	hasContext := false
+	if len(parameters) > 0 {
+		firstParamType := parameters[0].Type().ReflectedType()
+		contextType := reflect.TypeOf((*context.Context)(nil)).Elem()
+		if firstParamType.Implements(contextType) {
+			hasContext = true
+		}
+	}
 	return &functionInfo{
 		reflectedFunctionValue: value,
 		funcType:               funcType,
 		returnType:             rt,
 		parameters:             parameters,
+		hasErrorReturn:         hasError,
+		hasContextParameter:    hasContext,
 	}, nil
 }
 
@@ -76,7 +91,7 @@ func (f functionInfo) Name() string {
 	return ""
 }
 
-// Parameters returns a slice of FunctionParameterInfo representing the parameters of the function.
+// Parameters Returns a slice of FunctionParameterInfo representing the parameters of the function.
 func (f functionInfo) Parameters() []types.FunctionParameterInfo {
 	return f.parameters
 }
@@ -89,6 +104,14 @@ func (f functionInfo) ParameterTypes() []types.ServiceType {
 	return parameterTypes
 }
 
+func (f functionInfo) HasErrorReturn() bool {
+	return f.hasErrorReturn
+}
+
+func (f functionInfo) ExpectsContextParameter() bool {
+	return f.hasContextParameter
+}
+
 // ReturnType returns the type of the service returned by the function.
 func (f functionInfo) ReturnType() types.ServiceType {
 	return f.returnType
@@ -97,21 +120,33 @@ func (f functionInfo) ReturnType() types.ServiceType {
 // String returns a string representation of the function's signature, including its name, parameters, and return type.
 func (f functionInfo) String() string {
 	parameterTypeNames := make([]string, len(f.parameters))
-	for _, t := range f.parameters {
-		parameterTypeNames[0] = t.String()
+	for i, t := range f.parameters {
+		parameterTypeNames[i] = t.String()
 	}
 	reflectedReturnType := f.returnType.ReflectedType()
 	funcTypeName := reflectedReturnType.String()
 	return fmt.Sprintf("%s(%s) %s", f.Name(), strings.Join(parameterTypeNames, ","), funcTypeName)
 }
 
-func returnType(funcType reflect.Type) (types.ServiceType, error) {
+func returnType(funcType reflect.Type) (types.ServiceType, bool, error) {
 	numReturnValues := funcType.NumOut()
-	if numReturnValues != 1 {
-		return nil, types.NewReflectionError(ErrorReturnTypeHasToHaveExactlyOnReturnValue)
+	const (
+		serviceTypeIndex = 0
+		errorTypeIndex   = 1
+	)
+	if numReturnValues == 1 {
+		serviceType := funcType.Out(serviceTypeIndex)
+		return types.ServiceTypeFrom(serviceType), false, nil
 	}
-	serviceType := funcType.Out(0)
-	return types.ServiceTypeFrom(serviceType), nil
+	if numReturnValues == 2 {
+		serviceType := funcType.Out(serviceTypeIndex)
+		errorType := funcType.Out(errorTypeIndex)
+		if isErrorType(errorType) {
+			return types.ServiceTypeFrom(serviceType), true, nil
+		}
+		return nil, false, types.NewReflectionError(ErrorSecondReturnTypeIsNotErr)
+	}
+	return nil, false, types.NewReflectionError(ErrorReturnTypeHasToHaveExactlyOnReturnValue)
 }
 
 func parameterInfos(funcType reflect.Type) []types.FunctionParameterInfo {
@@ -126,4 +161,9 @@ func parameterInfos(funcType reflect.Type) []types.FunctionParameterInfo {
 		parameters = append(parameters, p)
 	}
 	return parameters
+}
+
+func isErrorType(t reflect.Type) bool {
+	errorType := reflect.TypeOf((*error)(nil))
+	return t.Implements(errorType.Elem())
 }

--- a/internal/tests/core/function_info_test.go
+++ b/internal/tests/core/function_info_test.go
@@ -1,12 +1,13 @@
 package core
 
 import (
-	"errors"
+	"context"
 	"fmt"
-	"github.com/matzefriedrich/parsley/internal/core"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+
+	"github.com/matzefriedrich/parsley/internal/core"
+	"github.com/stretchr/testify/assert"
 )
 
 type expectedFunctionInfo struct {
@@ -29,11 +30,11 @@ func Test_FunctionInfo_ReflectFunctionInfoFrom_variable_returns_error(t *testing
 	assert.ErrorIs(t, err, core.ErrNotAFunction)
 }
 
-func Test_FunctionInfo_ReflectFunctionInfoFrom_function_with_multiple_return_values_returns_error(t *testing.T) {
+func Test_FunctionInfo_ReflectFunctionInfoFrom_function_with_three_return_values_returns_error(t *testing.T) {
 
 	// Arrange
-	f := func() (some, error) {
-		return nil, errors.New("this is an error")
+	f := func() (some, error, error) {
+		return nil, nil, nil
 	}
 
 	// Act
@@ -42,6 +43,21 @@ func Test_FunctionInfo_ReflectFunctionInfoFrom_function_with_multiple_return_val
 	// Assert
 	assert.Error(t, err)
 	assert.ErrorIs(t, err, core.ErrReturnTypeHasToHaveExactlyOnReturnValue)
+}
+
+func Test_FunctionInfo_ReflectFunctionInfoFrom_function_with_two_return_values_including_error_succeeds(t *testing.T) {
+
+	// Arrange
+	f := func() (some, error) {
+		return nil, nil
+	}
+
+	// Act
+	info, err := core.ReflectFunctionInfoFrom(reflect.ValueOf(f))
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, info.HasErrorReturn())
 }
 
 func Test_FunctionInfo_ReflectFunctionInfoFrom_local_function_returning_an_interface(t *testing.T) {
@@ -97,6 +113,67 @@ func Test_FunctionInfo_ReflectFunctionInfoFrom_named_function_with_parameters_re
 	reflectFunctionInfoFromTestHelper(t, functionWithParametersReturningAnInterface, expected)
 }
 
+func Test_ReflectFunctionInfoFrom_verify_activator_function_parameters_and_return_values(t *testing.T) {
+
+	t.Run("Standard function", func(t *testing.T) {
+		// Arrange
+		f := func(a dummy, b dummy) dummy { return dummy{} }
+
+		// Act
+		info, err := core.ReflectFunctionInfoFrom(reflect.ValueOf(f))
+
+		// Assert
+		assert.NoError(t, err)
+		assert.False(t, info.HasErrorReturn())
+		assert.False(t, info.HasContextParameter())
+		assert.Equal(t, "dummy", info.ReturnType().Name())
+		assert.Len(t, info.Parameters(), 2)
+		assert.Contains(t, info.String(), "(core.dummy,core.dummy) core.dummy")
+	})
+
+	t.Run("Function with error return", func(t *testing.T) {
+		// Arrange
+		f := func() (dummy, error) { return dummy{}, nil }
+
+		// Act
+		info, err := core.ReflectFunctionInfoFrom(reflect.ValueOf(f))
+
+		// Assert
+		assert.NoError(t, err)
+		assert.True(t, info.HasErrorReturn())
+		assert.Equal(t, "dummy", info.ReturnType().Name())
+		assert.Contains(t, info.String(), "() core.dummy")
+	})
+
+	t.Run("Function with context parameter", func(t *testing.T) {
+		// Arrange
+		f := func(ctx context.Context, s dummy) dummy { return dummy{} }
+
+		// Act
+		info, err := core.ReflectFunctionInfoFrom(reflect.ValueOf(f))
+
+		// Assert
+		assert.NoError(t, err)
+		assert.True(t, info.HasContextParameter())
+		assert.Len(t, info.Parameters(), 2)
+		assert.Contains(t, info.String(), "(context.Context,core.dummy) core.dummy")
+	})
+
+	t.Run("Function with context and error", func(t *testing.T) {
+		// Arrange
+		f := func(ctx context.Context) (dummy, error) { return dummy{}, nil }
+
+		// Act
+		info, err := core.ReflectFunctionInfoFrom(reflect.ValueOf(f))
+
+		// Arrange
+		assert.NoError(t, err)
+		assert.True(t, info.HasContextParameter())
+		assert.True(t, info.HasErrorReturn())
+		assert.Contains(t, info.String(), "(context.Context) core.dummy")
+	})
+}
+
 func functionReturningAnInterface() some {
 	return nil
 }
@@ -132,3 +209,5 @@ func reflectFunctionInfoFromTestHelper(t *testing.T, target any, expected expect
 
 type some interface {
 }
+
+type dummy struct{}

--- a/internal/tests/core/function_info_test.go
+++ b/internal/tests/core/function_info_test.go
@@ -125,7 +125,7 @@ func Test_ReflectFunctionInfoFrom_verify_activator_function_parameters_and_retur
 		// Assert
 		assert.NoError(t, err)
 		assert.False(t, info.HasErrorReturn())
-		assert.False(t, info.HasContextParameter())
+		assert.False(t, info.ExpectsContextParameter())
 		assert.Equal(t, "dummy", info.ReturnType().Name())
 		assert.Len(t, info.Parameters(), 2)
 		assert.Contains(t, info.String(), "(core.dummy,core.dummy) core.dummy")
@@ -154,7 +154,7 @@ func Test_ReflectFunctionInfoFrom_verify_activator_function_parameters_and_retur
 
 		// Assert
 		assert.NoError(t, err)
-		assert.True(t, info.HasContextParameter())
+		assert.True(t, info.ExpectsContextParameter())
 		assert.Len(t, info.Parameters(), 2)
 		assert.Contains(t, info.String(), "(context.Context,core.dummy) core.dummy")
 	})
@@ -168,7 +168,7 @@ func Test_ReflectFunctionInfoFrom_verify_activator_function_parameters_and_retur
 
 		// Arrange
 		assert.NoError(t, err)
-		assert.True(t, info.HasContextParameter())
+		assert.True(t, info.ExpectsContextParameter())
 		assert.True(t, info.HasErrorReturn())
 		assert.Contains(t, info.String(), "(context.Context) core.dummy")
 	})

--- a/internal/tests/features/register_proxy_error_test.go
+++ b/internal/tests/features/register_proxy_error_test.go
@@ -52,7 +52,7 @@ func Test_Register_generated_proxy_type_handles_error(t *testing.T) {
 	_ = registry.Register(newMethodErrorInterceptor(collector), types.LifetimeSingleton)
 	_ = registry.Register(NewGreeterProxyImpl, types.LifetimeTransient)
 	_ = registry.Register(newJohnGreeter, types.LifetimeTransient)
-	_ = features.RegisterList[features.MethodInterceptor](ctx, registry)
+	_ = features.RegisterList[features.MethodInterceptor](registry)
 
 	resolver := resolving.NewResolver(registry)
 	resolverContext := resolving.NewScopedContext(ctx)

--- a/internal/tests/features/register_proxy_test.go
+++ b/internal/tests/features/register_proxy_test.go
@@ -20,7 +20,7 @@ func Test_Register_generated_proxy_type(t *testing.T) {
 	_ = registry.Register(newMethodCallInterceptor(collector), types.LifetimeSingleton)
 	_ = registry.Register(NewGreeterProxyImpl, types.LifetimeTransient)
 	_ = registry.Register(newGreeter, types.LifetimeTransient)
-	_ = features.RegisterList[features.MethodInterceptor](ctx, registry)
+	_ = features.RegisterList[features.MethodInterceptor](registry)
 
 	resolver := resolving.NewResolver(registry)
 	resolverContext := resolving.NewScopedContext(ctx)

--- a/internal/tests/features/registry_register_list_test.go
+++ b/internal/tests/features/registry_register_list_test.go
@@ -18,7 +18,7 @@ func Test_Resolver_register_list_resolver(t *testing.T) {
 	registry := registration.NewServiceRegistry()
 	_ = registry.Register(newLocalDataService, types.LifetimeTransient)
 	_ = registry.Register(newRemoteDataService, types.LifetimeTransient)
-	_ = features.RegisterList[dataService](ctx, registry)
+	_ = features.RegisterList[dataService](registry)
 
 	resolver := resolving.NewResolver(registry)
 	resolverContext := resolving.NewScopedContext(ctx)
@@ -39,7 +39,7 @@ func Test_Resolver_resolve_multiple_instances_of_type(t *testing.T) {
 	registry := registration.NewServiceRegistry()
 	_ = registry.Register(newLocalDataService, types.LifetimeTransient)
 	_ = registry.Register(newRemoteDataService, types.LifetimeTransient)
-	_ = features.RegisterList[dataService](ctx, registry)
+	_ = features.RegisterList[dataService](registry)
 	_ = registry.Register(newControllerWithServiceList, types.LifetimeTransient)
 
 	resolver := resolving.NewResolver(registry)

--- a/internal/tests/features/registry_register_named_test.go
+++ b/internal/tests/features/registry_register_named_test.go
@@ -97,7 +97,7 @@ func Test_Registry_register_named_service_resolve_all_named_services_as_list(t *
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
 
-	_ = features.RegisterList[dataService](ctx, registry)
+	_ = features.RegisterList[dataService](registry)
 
 	resolver := resolving.NewResolver(registry)
 	scopedContext := resolving.NewScopedContext(ctx)

--- a/internal/tests/features/reproduce_nil_param_test.go
+++ b/internal/tests/features/reproduce_nil_param_test.go
@@ -21,7 +21,7 @@ func Test_Proxy_reflect_parameter_type_nil_value(t *testing.T) {
 	_ = registry.Register(newNilParamInterceptor(collector), types.LifetimeSingleton)
 	_ = registry.Register(NewNilParamReproProxyImpl, types.LifetimeTransient)
 	_ = registry.Register(newNilParamReproImpl, types.LifetimeTransient)
-	_ = features.RegisterList[features.MethodInterceptor](ctx, registry)
+	_ = features.RegisterList[features.MethodInterceptor](registry)
 
 	resolver := resolving.NewResolver(registry)
 	resolverContext := resolving.NewScopedContext(ctx)

--- a/internal/tests/resolving/resolver_activator_func_signatures_test.go
+++ b/internal/tests/resolving/resolver_activator_func_signatures_test.go
@@ -1,0 +1,123 @@
+package resolving
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Resolver_verify_different_activator_function_signatures(t *testing.T) {
+
+	t.Run("Support (T, error) success", func(t *testing.T) {
+		// Arrange
+		registry := registration.NewServiceRegistry()
+		activatorFuncWithError := func() (ServiceA, error) {
+			return &serviceA{val: "A"}, nil
+		}
+		_ = registry.Register(activatorFuncWithError, types.LifetimeTransient)
+		resolver := resolving.NewResolver(registry)
+
+		ctx := t.Context()
+
+		// Act
+		actual, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)
+
+		assert.NoError(t, err)
+		assert.Equal(t, "A", actual.DoA())
+	})
+
+	t.Run("Support (T, error) failure", func(t *testing.T) {
+		// Arrange
+		registry := registration.NewServiceRegistry()
+		failingActivatorFuncWithError := func() (ServiceA, error) {
+			return nil, errors.New("failed to create A")
+		}
+		_ = registry.Register(failingActivatorFuncWithError, types.LifetimeTransient)
+		resolver := resolving.NewResolver(registry)
+
+		ctx := t.Context()
+
+		// Act
+		_, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)
+
+		// Assert
+		assert.Error(t, err)
+		assert.Contains(t, errors.Unwrap(err).Error(), "failed to create A")
+	})
+
+	t.Run("Support (context.Context, ...) T", func(t *testing.T) {
+		// Arrange
+		registry := registration.NewServiceRegistry()
+		activatorFuncWithContext := func(activatorCtx context.Context) ServiceA {
+			val := activatorCtx.Value("test-key").(string)
+			return &serviceA{val: val}
+		}
+		_ = registry.Register(activatorFuncWithContext, types.LifetimeTransient)
+		resolver := resolving.NewResolver(registry)
+
+		ctx := context.WithValue(t.Context(), "test-key", "context-A")
+
+		// Act
+		actual, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, "context-A", actual.DoA())
+	})
+
+	t.Run("Support (context.Context, ...) (T, error)", func(t *testing.T) {
+		// Arrange
+		registry := registration.NewServiceRegistry()
+		failingActivatorFuncWithContext := func(ctx context.Context) (ServiceA, error) {
+			val := ctx.Value("test-key").(string)
+			return &serviceA{val: val}, nil
+		}
+		_ = registry.Register(failingActivatorFuncWithContext, types.LifetimeTransient)
+		resolver := resolving.NewResolver(registry)
+
+		ctx := context.WithValue(t.Context(), "test-key", "context-A-error")
+
+		// Act
+		actual, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, "context-A-error", actual.DoA())
+	})
+
+	t.Run("Support standard T", func(t *testing.T) {
+		// Arrange
+		registry := registration.NewServiceRegistry()
+		activatorFunc := func() ServiceA {
+			return &serviceA{val: "A"}
+		}
+		_ = registry.Register(activatorFunc, types.LifetimeTransient)
+		resolver := resolving.NewResolver(registry)
+
+		ctx := context.Background()
+
+		// Act
+		svc, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, "A", svc.DoA())
+	})
+}
+
+type ServiceA interface {
+	DoA() string
+}
+
+type serviceA struct {
+	val string
+}
+
+func (s *serviceA) DoA() string {
+	return s.val
+}

--- a/internal/tests/resolving/resolver_activator_func_signatures_test.go
+++ b/internal/tests/resolving/resolver_activator_func_signatures_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/matzefriedrich/parsley/internal/core"
 	"github.com/matzefriedrich/parsley/pkg/registration"
 	"github.com/matzefriedrich/parsley/pkg/resolving"
 	"github.com/matzefriedrich/parsley/pkg/types"
@@ -53,14 +54,15 @@ func Test_Resolver_verify_different_activator_function_signatures(t *testing.T) 
 	t.Run("Support (context.Context, ...) T", func(t *testing.T) {
 		// Arrange
 		registry := registration.NewServiceRegistry()
+		contextKey := core.ContextKey("test-key")
 		activatorFuncWithContext := func(activatorCtx context.Context) ServiceA {
-			val := activatorCtx.Value("test-key").(string)
+			val := activatorCtx.Value(contextKey).(string)
 			return &serviceA{val: val}
 		}
 		_ = registry.Register(activatorFuncWithContext, types.LifetimeTransient)
 		resolver := resolving.NewResolver(registry)
 
-		ctx := context.WithValue(t.Context(), "test-key", "context-A")
+		ctx := context.WithValue(t.Context(), contextKey, "context-A")
 
 		// Act
 		actual, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)
@@ -73,14 +75,15 @@ func Test_Resolver_verify_different_activator_function_signatures(t *testing.T) 
 	t.Run("Support (context.Context, ...) (T, error)", func(t *testing.T) {
 		// Arrange
 		registry := registration.NewServiceRegistry()
+		contextKey := core.ContextKey("test-key")
 		failingActivatorFuncWithContext := func(ctx context.Context) (ServiceA, error) {
-			val := ctx.Value("test-key").(string)
+			val := ctx.Value(contextKey).(string)
 			return &serviceA{val: val}, nil
 		}
 		_ = registry.Register(failingActivatorFuncWithContext, types.LifetimeTransient)
 		resolver := resolving.NewResolver(registry)
 
-		ctx := context.WithValue(t.Context(), "test-key", "context-A-error")
+		ctx := context.WithValue(t.Context(), contextKey, "context-A-error")
 
 		// Act
 		actual, err := resolving.ResolveRequiredService[ServiceA](ctx, resolver)

--- a/pkg/bootstrap/application.go
+++ b/pkg/bootstrap/application.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/matzefriedrich/parsley/internal/core"
 	"github.com/matzefriedrich/parsley/pkg/registration"
 	"github.com/matzefriedrich/parsley/pkg/resolving"
 	"github.com/matzefriedrich/parsley/pkg/types"
@@ -24,8 +25,6 @@ var (
 	ErrCannotRegisterAppFactory = errors.New(ErrorCannotRegisterAppFactory)
 )
 
-var parsley infrastructure
-
 // RunParsleyApplication initializes and runs the Parsley application lifecycle.
 // It registers the application factory, configures additional modules, resolves the main application instance, and invokes its Run method.
 func RunParsleyApplication(cxt context.Context, appFactoryFunc any, configure ...types.ModuleFunc) error {
@@ -45,11 +44,13 @@ func RunParsleyApplication(cxt context.Context, appFactoryFunc any, configure ..
 	ctx := resolving.NewScopedContext(cxt)
 	app, _ := resolving.ResolveRequiredService[Application](ctx, resolver)
 
-	parsley = infrastructure{
+	parsley := infrastructure{
 		registry: registry,
 		resolver: resolver,
 		app:      app,
 	}
 
-	return app.Run(ctx)
+	appContext := context.WithValue(ctx, core.ContextKey("__parsley-infrastructure"), parsley)
+
+	return app.Run(appContext)
 }

--- a/pkg/features/list_services.go
+++ b/pkg/features/list_services.go
@@ -8,8 +8,8 @@ import (
 )
 
 // RegisterList registers a function that resolves and returns a list of services of type T with the specified registry.
-func RegisterList[T any](ctx context.Context, registry types.ServiceRegistry) error {
-	return registry.Register(func(resolver types.Resolver) []T {
+func RegisterList[T any](registry types.ServiceRegistry) error {
+	return registry.Register(func(ctx context.Context, resolver types.Resolver) []T {
 		services, _ := resolving.ResolveRequiredServices[T](ctx, resolver)
 		return services
 	}, types.LifetimeTransient)

--- a/pkg/registration/dependency.go
+++ b/pkg/registration/dependency.go
@@ -1,8 +1,10 @@
 package registration
 
 import (
-	"github.com/matzefriedrich/parsley/pkg/types"
+	"context"
 	"sync"
+
+	"github.com/matzefriedrich/parsley/pkg/types"
 )
 
 type dependencyInfo struct {
@@ -61,12 +63,12 @@ func (d *dependencyInfo) RequiredServices() ([]interface{}, error) {
 
 // CreateInstance initializes and returns the service instance for this dependency.
 // It resolves required services and uses the activator to create the instance.
-func (d *dependencyInfo) CreateInstance() (interface{}, error) {
+func (d *dependencyInfo) CreateInstance(ctx context.Context) (interface{}, error) {
 	if d.instance != nil {
 		return d.instance, nil
 	}
 	resolvedDependencies, _ := d.RequiredServices()
-	instance, err := d.registration.InvokeActivator(resolvedDependencies...)
+	instance, err := d.registration.InvokeActivator(ctx, resolvedDependencies...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/registration/service_registration.go
+++ b/pkg/registration/service_registration.go
@@ -1,6 +1,7 @@
 package registration
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -11,11 +12,13 @@ import (
 )
 
 type serviceRegistration struct {
-	id            uint64
-	serviceType   typeInfo
-	activatorFunc reflect.Value
-	parameters    []typeInfo
-	lifetimeScope types.LifetimeScope
+	id                  uint64
+	serviceType         typeInfo
+	activatorFunc       reflect.Value
+	parameters          []typeInfo
+	lifetimeScope       types.LifetimeScope
+	hasErrorReturn      bool
+	hasContextParameter bool
 }
 
 type typeInfo struct {
@@ -31,23 +34,39 @@ func newTypeInfo(t types.ServiceType) typeInfo {
 }
 
 // InvokeActivator calls the activator function stored in the service registration with the provided parameters.
-func (s *serviceRegistration) InvokeActivator(params ...interface{}) (interface{}, error) {
+func (s *serviceRegistration) InvokeActivator(ctx context.Context, params ...interface{}) (interface{}, error) {
 	var values []reflect.Value
-	if len(params) > 0 {
-		values = make([]reflect.Value, len(params))
-		for i, p := range params {
-			values[i] = reflect.ValueOf(p)
-		}
+	offset := 0
+	if s.hasContextParameter {
+		offset = 1
+	}
+	values = make([]reflect.Value, len(params)+offset)
+	if s.hasContextParameter {
+		values[0] = reflect.ValueOf(ctx)
+	}
+	for i, p := range params {
+		values[i+offset] = reflect.ValueOf(p)
 	}
 	result := s.activatorFunc.Call(values)
-	if len(result) != 1 {
-		return nil, fmt.Errorf("activator function returned %d values", len(result))
+	if s.hasErrorReturn {
+		if len(result) != 2 {
+			return nil, fmt.Errorf("activator function returned %d values, expected 2", len(result))
+		}
+		errValue := result[1].Interface()
+		if errValue != nil {
+			activationErr := errValue.(error)
+			return nil, fmt.Errorf("service activation failed: %w", activationErr)
+		}
+	} else {
+		if len(result) != 1 {
+			return nil, fmt.Errorf("activator function returned %d values, expected 1", len(result))
+		}
 	}
 	serviceInstance := result[0]
 	return serviceInstance.Interface(), nil
 }
 
-// Id returns the unique identifier of this service registration.
+// Id Returns the unique identifier of this service registration.
 func (s *serviceRegistration) Id() uint64 {
 	return s.id
 }
@@ -83,9 +102,13 @@ func (s *serviceRegistration) LifetimeScope() types.LifetimeScope {
 
 // RequiredServiceTypes returns a slice of ServiceType representing the service dependencies.
 func (s *serviceRegistration) RequiredServiceTypes() []types.ServiceType {
-	requiredTypes := make([]types.ServiceType, len(s.parameters))
-	for i, p := range s.parameters {
-		requiredTypes[i] = p.t
+	offset := 0
+	if s.hasContextParameter {
+		offset = 1
+	}
+	requiredTypes := make([]types.ServiceType, len(s.parameters)-offset)
+	for i := offset; i < len(s.parameters); i++ {
+		requiredTypes[i-offset] = s.parameters[i].t
 	}
 	return requiredTypes
 }
@@ -127,7 +150,10 @@ func CreateServiceRegistration(activatorFunc any, lifetimeScope types.LifetimeSc
 		fallthrough
 	case reflect.Interface:
 		requiredTypes := info.ParameterTypes()
-		return newServiceRegistration(serviceType, lifetimeScope, value, requiredTypes...), nil
+		reg := newServiceRegistration(serviceType, lifetimeScope, value, requiredTypes...)
+		reg.hasErrorReturn = info.HasErrorReturn()
+		reg.hasContextParameter = info.ExpectsContextParameter()
+		return reg, nil
 	default:
 		return nil, types.NewRegistryError(types.ErrorActivatorFunctionInvalidReturnType)
 	}

--- a/pkg/resolving/resolver.go
+++ b/pkg/resolving/resolver.go
@@ -163,7 +163,7 @@ func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.Ser
 				continue
 			}
 
-			instance, err := next.CreateInstance()
+			instance, err := next.CreateInstance(ctx)
 			if err != nil {
 				return nil, types.NewResolverError(types.ErrorCannotResolveService, types.WithCause(err), types.ForServiceType(next.ServiceTypeName()))
 			}

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -13,6 +13,8 @@ type FunctionInfo interface {
 	Parameters() []FunctionParameterInfo
 	ReturnType() ServiceType
 	ParameterTypes() []ServiceType
+	HasErrorReturn() bool
+	ExpectsContextParameter() bool
 }
 
 type FunctionParameterInfo interface {
@@ -99,7 +101,7 @@ type ServiceRegistration interface {
 	Id() uint64
 
 	// InvokeActivator calls the activator function with the provided parameters and returns the resulting instance and any error.
-	InvokeActivator(params ...interface{}) (interface{}, error)
+	InvokeActivator(ctx context.Context, params ...interface{}) (interface{}, error)
 
 	// IsSame checks if the provided ServiceRegistration equals the current ServiceRegistration.
 	IsSame(other ServiceRegistration) bool
@@ -164,7 +166,7 @@ type DependencyInfo interface {
 	AddRequiredServiceInfo(child DependencyInfo)
 
 	// CreateInstance creates an instance of the service associated with this dependency info.
-	CreateInstance() (interface{}, error)
+	CreateInstance(ctx context.Context) (interface{}, error)
 
 	// Consumer returns the parent dependency for the current dependency info.
 	Consumer() DependencyInfo


### PR DESCRIPTION
This PR enhances parsley activator functions factories to support standard Go idioms for context propagation and error handling. Previously, activators were restricted to returning exactly one value and could not receive a ` context.Context`  from the container.

With these changes, the following activator signatures are now supported:

- `func(...) (T, error)`
- `func(context.Context, ...) T`
- `func(context.Context, ...) (T, error)`

### Key Changes

- **Metadata Layer:** Updated `FunctionInfo` and the reflection logic in `internal/core/function_info.go` to detect `context.Context` parameters as the first argument and optional error return values.
- **Internal Interfaces:** Updated `ServiceRegistration.InvokeActivator` and `DependencyInfo.CreateInstance` in `pkg/types/types.go` to accept `context.Context`.
- **Activation Logic:** Updated `InvokeActivator` in `pkg/registration/service_registration.go` to:
  - Automatically inject the provided `context.Context` if the activator requires it.
  - Handle and propagate errors returned by the activator function.
  - Exclude `context.Context` from the required service types so the resolver doesn't attempt to resolve it as a registered dependency.
- **Resolution Layer:** Propagated the context from `Resolver.ResolveWithOptions` down to the activator.
- **Bug fix:** Fixed a bug in `FunctionInfo.String()` where function signature parameters were not correctly formatted.

### Breaking Changes Internal

While this update maintains backward compatibility for existing activator functions, it introduces breaking changes to the internal interfaces `ServiceRegistration` and `DependencyInfo`. Any custom implementations of these interfaces will need to be updated to accept the `context.Context` parameter.