### PR TITLE
refactor: remove context from RegisterNamed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-* Removes the `context.Context` parameter from `RegisterNamed`; the registered named service activator function does now use the resolver context.
-* Updates internal reflection calls to use `reflect.Pointer` instead of the deprecated `reflect.Ptr` (modern Go idiom).
+* Upgrades Go version to 1.26.4
+* Removes the `context.Context` parameter from `RegisterNamed`; the registered named service activator function does now use the resolver context. [#87](https://github.com/matzefriedrich/parsley/pull/87)
+* Updates internal reflection calls to use `reflect.Pointer` instead of the deprecated `reflect.Ptr` (modern Go idiom). [#87](https://github.com/matzefriedrich/parsley/pull/87
 * Bumps `golang.org/x/mod` from 0.37.0 to 0.38.0 [#86](https://github.com/matzefriedrich/parsley/pull/86)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [unreleased]
+## [v1.5.2] - 2026-07-22
 
 ### Changed
 
+* Removes the `context.Context` parameter from `RegisterNamed`; the registered named service activator function does now use the resolver context.
+* Updates internal reflection calls to use `reflect.Pointer` instead of the deprecated `reflect.Ptr` (modern Go idiom).
 * Bumps `golang.org/x/mod` from 0.37.0 to 0.38.0 [#86](https://github.com/matzefriedrich/parsley/pull/86)
 
 

--- a/internal/tests/features/registry_register_named_test.go
+++ b/internal/tests/features/registry_register_named_test.go
@@ -16,7 +16,7 @@ func Test_Registry_register_named_service_resolve_factory(t *testing.T) {
 	registry := registration.NewServiceRegistry()
 
 	// Act
-	err := features.RegisterNamed[dataService](t.Context(), registry,
+	err := features.RegisterNamed[dataService](registry,
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
 
@@ -41,7 +41,7 @@ func Test_Registry_register_named_service_consume_factory(t *testing.T) {
 
 	registry := registration.NewServiceRegistry()
 	_ = registration.RegisterSingleton(registry, newControllerWithNamedServiceFactory)
-	_ = features.RegisterNamed[dataService](ctx, registry,
+	_ = features.RegisterNamed[dataService](registry,
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
 
@@ -64,7 +64,7 @@ func Test_Registry_register_named_service_resolve_all_named_services(t *testing.
 	ctx := t.Context()
 
 	registry := registration.NewServiceRegistry()
-	_ = features.RegisterNamed[dataService](ctx, registry,
+	_ = features.RegisterNamed[dataService](registry,
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
 
@@ -93,7 +93,7 @@ func Test_Registry_register_named_service_resolve_all_named_services_as_list(t *
 	ctx := t.Context()
 
 	registry := registration.NewServiceRegistry()
-	_ = features.RegisterNamed[dataService](ctx, registry,
+	_ = features.RegisterNamed[dataService](registry,
 		registration.NamedServiceRegistration("remote", newRemoteDataService, types.LifetimeSingleton),
 		registration.NamedServiceRegistration("local", newLocalDataService, types.LifetimeTransient))
 
@@ -117,7 +117,7 @@ func Test_Registry_register_named_service_invalid_registration(t *testing.T) {
 	registry := registration.NewServiceRegistry()
 
 	// Act
-	err := features.RegisterNamed[dataService](t.Context(), registry,
+	err := features.RegisterNamed[dataService](registry,
 		func() (string, any, types.LifetimeScope) {
 			return "", nil, types.LifetimeTransient
 		})

--- a/internal/validation.go
+++ b/internal/validation.go
@@ -7,7 +7,7 @@ func IsNil[T any](instance T) bool {
 	// Use reflection to check if instance is nil
 	val := reflect.ValueOf(instance)
 	switch val.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
 		return val.IsNil()
 	case reflect.Invalid:
 		return true

--- a/pkg/features/named_services.go
+++ b/pkg/features/named_services.go
@@ -1,8 +1,6 @@
 package features
 
 import (
-	"context"
-
 	"github.com/matzefriedrich/parsley/pkg/registration"
 	"github.com/matzefriedrich/parsley/pkg/resolving"
 	"github.com/matzefriedrich/parsley/pkg/types"
@@ -25,7 +23,7 @@ func (n namedService) Name() string {
 
 // RegisterNamed registers named services with their respective activator functions and lifetime scopes.
 // It supports dependency injection by associating names with service instances.
-func RegisterNamed[T any](ctx context.Context, registry types.ServiceRegistry, services ...registration.NamedServiceRegistrationFunc) error {
+func RegisterNamed[T any](registry types.ServiceRegistry, services ...registration.NamedServiceRegistrationFunc) error {
 
 	registrationErrors := make([]error, 0)
 
@@ -42,7 +40,7 @@ func RegisterNamed[T any](ctx context.Context, registry types.ServiceRegistry, s
 		}
 	}
 
-	nameServiceResolver := resolving.CreateNamedServiceResolverActivatorFunc[T](ctx)
+	nameServiceResolver := resolving.CreateNamedServiceResolverActivatorFunc[T]()
 	err := registration.RegisterTransient(registry, nameServiceResolver)
 	if err != nil {
 		registrationErrors = append(registrationErrors, err)

--- a/pkg/resolving/named_service_resolver.go
+++ b/pkg/resolving/named_service_resolver.go
@@ -7,11 +7,11 @@ import (
 )
 
 // NamedServiceResolverActivatorFunc defines a function for resolving named services.
-type NamedServiceResolverActivatorFunc[T any] func(types.Resolver) func(string) (T, error)
+type NamedServiceResolverActivatorFunc[T any] func(context.Context, types.Resolver) func(string) (T, error)
 
 // CreateNamedServiceResolverActivatorFunc creates a NamedServiceResolverActivatorFunc for resolving named services.
-func CreateNamedServiceResolverActivatorFunc[T any](ctx context.Context) NamedServiceResolverActivatorFunc[T] {
-	return func(resolver types.Resolver) func(string) (T, error) {
+func CreateNamedServiceResolverActivatorFunc[T any]() NamedServiceResolverActivatorFunc[T] {
+	return func(ctx context.Context, resolver types.Resolver) func(string) (T, error) {
 		var nilInstance T
 		requiredServices, _ := ResolveRequiredServices[func() types.NamedService[T]](ctx, resolver)
 		return func(name string) (T, error) {

--- a/pkg/types/service_type.go
+++ b/pkg/types/service_type.go
@@ -52,7 +52,7 @@ func ServiceTypeFrom(t reflect.Type) ServiceType {
 	isList := false
 	elemType := t
 	switch t.Kind() {
-	case reflect.Ptr:
+	case reflect.Pointer:
 		elemType = t.Elem()
 	case reflect.Interface:
 		break


### PR DESCRIPTION
The `context.Context` in `RegisterNamed` was found to be redundant at registration time. Moving it to the resolution stage makes the API cleaner and more consistent with other registration functions in the library.

#### Changes
- **API Refactoring**: Removed the `context.Context` parameter from `features.RegisterNamed`. The context is no longer required during registration and is now correctly handled at the resolution stage within the activator.
- **Modernization**: Replaced deprecated `reflect.Ptr` with `reflect.Pointer` across the codebase (specifically in `internal/validation.go` and `internal/types/service_type.go`). This follows Go's recommendation for codebases targeting Go 1.18 and later.
- **Internal Alignment**:
    - Updated `NamedServiceResolverActivatorFunc` to accept `context.Context` during invocation.
    - Updated `CreateNamedServiceResolverActivatorFunc` to remove the context parameter, as it was redundant for factory creation.