### PR TITLE
refactor: improve error handling and formatting for resolver and registry errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.6.0] - 2026-07-25
+
+### Added
+
+* Introduced `ParsleyErrorWithServiceTypeName` interface and `ServiceTypeName()` getter for `ResolverError` and `RegistryError` to provide access to the affected service type. [#88](https://github.com/matzefriedrich/parsley/pull/88)
+* Added `ForServiceType[T]` and `ForServiceTypeByName` error initializers to enrich errors with service type information. [#88](https://github.com/matzefriedrich/parsley/pull/88)
+* Added `NewResolverErrorForType[T]` utility function for creating resolver errors with type context. [#88](https://github.com/matzefriedrich/parsley/pull/88)
+
+### Changed
+
+* Refactored `ResolverError` and `RegistryError` to implement `fmt.Formatter`. Formatted output (e.g., via `%v` or `%+v`) now includes the service type name while `Error()` returns the base message, preserving compatibility with `errors.Is` and sentinel errors. [#88](https://github.com/matzefriedrich/parsley/pull/88)
+
+### Fixed
+
+* `ResolveRequiredService` and `ResolveRequiredServices` now include the missing service type name in the returned error when resolution fails. [#88](https://github.com/matzefriedrich/parsley/pull/88)
+
+
 ## [v1.5.2] - 2026-07-22
 
 ### Changed

--- a/internal/tests/types/registry_error_test.go
+++ b/internal/tests/types/registry_error_test.go
@@ -2,9 +2,10 @@ package types
 
 import (
 	"errors"
+	"testing"
+
 	"github.com/matzefriedrich/parsley/pkg/types"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func Test_NewRegistryError_initializer_gets_invoked_with_expected_error_instance(t *testing.T) {
@@ -13,7 +14,7 @@ func Test_NewRegistryError_initializer_gets_invoked_with_expected_error_instance
 	const expectedErrorMsg = "something went wrong"
 
 	// Act
-	actual := types.NewRegistryError(expectedErrorMsg, types.ForServiceType("Foo"))
+	actual := types.NewRegistryError(expectedErrorMsg, types.ForServiceTypeByName("Foo"))
 
 	// Assert
 	assert.ErrorIs(t, actual, &types.RegistryError{ParsleyError: types.ParsleyError{Msg: expectedErrorMsg}})
@@ -23,6 +24,6 @@ func Test_NewRegistryError_initializer_gets_invoked_with_expected_error_instance
 	isRegistryErr := errors.As(actual, &registryErr)
 	assert.True(t, isRegistryErr)
 
-	matchesServiceType := registryErr.MatchesServiceType("Foo")
+	matchesServiceType := registryErr.ServiceTypeName() == "Foo"
 	assert.True(t, matchesServiceType)
 }

--- a/internal/tests/types/resolver_error_test.go
+++ b/internal/tests/types/resolver_error_test.go
@@ -1,0 +1,41 @@
+package types_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolverError_ErrorsIs(t *testing.T) {
+	// Arrange
+	err := types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceTypeByName("MyService"))
+
+	// Act & Assert
+	assert.True(t, errors.Is(err, types.ErrServiceTypeNotRegistered))
+}
+
+func TestResolverError_Format(t *testing.T) {
+	// Arrange
+	err := types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceTypeByName("MyService"))
+
+	// Act
+	msg := fmt.Sprintf("%v", err)
+
+	// Assert
+	assert.Equal(t, "service type is not registered: MyService", msg)
+}
+
+func TestResolverError_Getter(t *testing.T) {
+	// Arrange
+	err := types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceTypeByName("MyService"))
+
+	// Act
+	withType, ok := err.(types.ParsleyErrorWithServiceTypeName)
+
+	// Assert
+	assert.True(t, ok)
+	assert.Equal(t, "MyService", withType.ServiceTypeName())
+}

--- a/pkg/registration/validator.go
+++ b/pkg/registration/validator.go
@@ -2,6 +2,7 @@ package registration
 
 import (
 	"fmt"
+
 	"github.com/matzefriedrich/parsley/internal"
 	"github.com/matzefriedrich/parsley/internal/utils"
 	"github.com/matzefriedrich/parsley/pkg/types"
@@ -116,7 +117,7 @@ func detectCircularDependency(sr types.ServiceRegistration, registry types.Servi
 		next := stack.Pop()
 		if next.Id() == sr.Id() {
 			serviceType := sr.ServiceType()
-			return types.NewRegistryError(ErrorCircularServiceRegistrationDetected, types.ForServiceType(serviceType.Name()))
+			return types.NewRegistryError(ErrorCircularServiceRegistrationDetected, types.ForServiceTypeByName(serviceType.Name()))
 		}
 		pushRequiredServices(next)
 	}

--- a/pkg/resolving/resolver.go
+++ b/pkg/resolving/resolver.go
@@ -25,7 +25,7 @@ func ResolveRequiredServices[T any](ctx context.Context, resolver types.Resolver
 	case reflect.Slice:
 	case reflect.Struct:
 	default:
-		return []T{}, types.NewResolverError(types.ErrorActivatorFunctionInvalidReturnType)
+		return []T{}, types.NewResolverErrorForType[T](types.ErrorActivatorFunctionInvalidReturnType)
 	}
 	resolvedInstances, err := resolver.Resolve(ctx, types.MakeServiceType[T]())
 	if err != nil {
@@ -50,9 +50,9 @@ func ResolveRequiredService[T any](ctx context.Context, resolver types.Resolver)
 	if len(services) == 1 {
 		return services[0], nil
 	} else if len(services) > 1 {
-		return nilInstance, types.NewResolverError(types.ErrorAmbiguousServiceInstancesResolved)
+		return nilInstance, types.NewResolverErrorForType[T](types.ErrorAmbiguousServiceInstancesResolved)
 	}
-	return nilInstance, types.NewResolverError(types.ErrorCannotResolveService)
+	return nilInstance, types.NewResolverErrorForType[T](types.ErrorCannotResolveService)
 }
 
 // NewResolver creates and returns a new Resolver instance based on the provided ServiceRegistry.
@@ -72,7 +72,7 @@ func detectCircularDependency(sr types.ServiceRegistration, consumer types.Depen
 		for stack.Any() {
 			next := stack.Pop()
 			if next.Registration().Id() == sr.Id() {
-				return types.NewResolverError(types.ErrorCircularDependencyDetected, types.ForServiceType(next.ServiceTypeName()))
+				return types.NewResolverError(types.ErrorCircularDependencyDetected, types.ForServiceTypeByName(next.ServiceTypeName()))
 			}
 			parent := next.Consumer()
 			if parent != nil {
@@ -101,7 +101,7 @@ func (r *resolver) Resolve(ctx context.Context, serviceType types.ServiceType) (
 }
 
 // ResolveWithOptions resolves instances for the given service type with the provided resolver options.
-func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.ServiceType, resolverOptions ...types.ResolverOptionsFunc) ([]interface{}, error) {
+func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.ServiceType, resolverOptions ...types.ResolverOptionsFunc) ([]any, error) {
 
 	registry, registryErr := r.createResolverRegistryAccessor(resolverOptions...)
 	if registryErr != nil {
@@ -110,10 +110,10 @@ func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.Ser
 
 	serviceRegistrationList, found := registry.TryGetServiceRegistrations(serviceType)
 	if !found {
-		return nil, types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceType(serviceType.Name()))
+		return nil, types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceTypeByName(serviceType.Name()))
 	}
 
-	resolvedInstances := make([]interface{}, 0)
+	resolvedInstances := make([]any, 0)
 
 	for _, serviceRegistration := range serviceRegistrationList.Registrations() {
 
@@ -137,11 +137,11 @@ func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.Ser
 			for _, requiredService := range requiredServices {
 				requiredServiceRegistration, isRegistered := registry.TryGetSingleServiceRegistration(requiredService)
 				if !isRegistered {
-					return nil, types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceType(requiredService.Name()))
+					return nil, types.NewResolverError(types.ErrorServiceTypeNotRegistered, types.ForServiceTypeByName(requiredService.Name()))
 				}
 				child, err := makeDependencyInfo(requiredServiceRegistration, next)
 				if err != nil {
-					return nil, types.NewResolverError(types.ErrorCannotBuildDependencyGraph, types.WithCause(err), types.ForServiceType(requiredService.Name()))
+					return nil, types.NewResolverError(types.ErrorCannotBuildDependencyGraph, types.WithCause(err), types.ForServiceTypeByName(requiredService.Name()))
 				}
 				if child.HasInstance() { // skip traversal if instance is already present
 					continue
@@ -165,7 +165,7 @@ func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.Ser
 
 			instance, err := next.CreateInstance(ctx)
 			if err != nil {
-				return nil, types.NewResolverError(types.ErrorCannotResolveService, types.WithCause(err), types.ForServiceType(next.ServiceTypeName()))
+				return nil, types.NewResolverError(types.ErrorCannotResolveService, types.WithCause(err), types.ForServiceTypeByName(next.ServiceTypeName()))
 			}
 
 			instances.KeepInstance(ctx, nextRegistration, instance)

--- a/pkg/types/error_formatter.go
+++ b/pkg/types/error_formatter.go
@@ -1,0 +1,29 @@
+package types
+
+import (
+	"fmt"
+)
+
+func formatError(msg string, serviceTypeName string, cause error, s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			_, _ = fmt.Fprint(s, msg)
+			if serviceTypeName != "" {
+				_, _ = fmt.Fprintf(s, ": %s", serviceTypeName)
+			}
+			if cause != nil {
+				_, _ = fmt.Fprintf(s, "\nCause: %+v", cause)
+			}
+			return
+		}
+		fallthrough
+	case 's':
+		_, _ = fmt.Fprint(s, msg)
+		if serviceTypeName != "" {
+			_, _ = fmt.Fprintf(s, ": %s", serviceTypeName)
+		}
+	case 'q':
+		_, _ = fmt.Fprintf(s, "%q", msg)
+	}
+}

--- a/pkg/types/parsley_error.go
+++ b/pkg/types/parsley_error.go
@@ -13,7 +13,7 @@ func (f ParsleyError) Error() string {
 	return f.Msg
 }
 
-// Unwrap returns the underlying cause of the ParsleyError, allowing for error unwrapping functionality.
+// Unwrap returns the underlying cause of the ParsleyError, allowing for error-unwrapping functionality.
 func (f ParsleyError) Unwrap() error {
 	return f.cause
 }
@@ -37,17 +37,32 @@ func WithCause(err error) ParsleyErrorFunc {
 	}
 }
 
-// ParsleyErrorWithServiceTypeName defines an interface for setting the service type name on errors.
+// ParsleyErrorWithServiceTypeName defines an interface for retrieving the service type name from errors.
 type ParsleyErrorWithServiceTypeName interface {
-	ServiceTypeName(name string)
+	ServiceTypeName() string
 }
 
-// ForServiceType creates a ParsleyErrorFunc that sets the service type name on errors that implement the ParsleyErrorWithServiceTypeName interface.
-func ForServiceType(serviceType string) ParsleyErrorFunc {
+type parsleyErrorWithServiceTypeNameSetter interface {
+	setServiceTypeName(name string)
+}
+
+// ForServiceType returns a ParsleyErrorFunc that sets the service type name on errors implementing ParsleyErrorWithServiceTypeName.
+func ForServiceType[T any]() ParsleyErrorFunc {
 	return func(e error) {
-		withServiceTypeErr, ok := e.(ParsleyErrorWithServiceTypeName)
+		withServiceTypeErr, ok := e.(parsleyErrorWithServiceTypeNameSetter)
 		if ok {
-			withServiceTypeErr.ServiceTypeName(serviceType)
+			serviceType := MakeServiceType[T]()
+			withServiceTypeErr.setServiceTypeName(serviceType.Name())
+		}
+	}
+}
+
+// ForServiceTypeByName returns a ParsleyErrorFunc that sets the service type name on errors implementing a specific interface.
+func ForServiceTypeByName(serviceType string) ParsleyErrorFunc {
+	return func(e error) {
+		withServiceTypeErr, ok := e.(parsleyErrorWithServiceTypeNameSetter)
+		if ok {
+			withServiceTypeErr.setServiceTypeName(serviceType)
 		}
 	}
 }

--- a/pkg/types/registry_error.go
+++ b/pkg/types/registry_error.go
@@ -1,6 +1,9 @@
 package types
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	ErrorRequiresFunctionValue               = "the given value is not function"
@@ -34,18 +37,29 @@ type RegistryError struct {
 // _ ensures that RegistryError implements the ParsleyErrorWithServiceTypeName interface.
 var _ ParsleyErrorWithServiceTypeName = &RegistryError{}
 
-// ServiceTypeName sets the service type name of the RegistryError.
-func (r *RegistryError) ServiceTypeName(name string) {
+func (r *RegistryError) setServiceTypeName(name string) {
 	r.serviceTypeName = name
+}
+
+// ServiceTypeName returns the service type name associated with the RegistryError.
+func (r *RegistryError) ServiceTypeName() string {
+	return r.serviceTypeName
+}
+
+// Error returns the message associated with the RegistryError.
+func (r *RegistryError) Error() string {
+	return r.Msg
+}
+
+// Format implements the fmt.Formatter interface.
+func (r *RegistryError) Format(s fmt.State, verb rune) {
+	formatError(r.Msg, r.serviceTypeName, r.cause, s, verb)
 }
 
 // MatchesServiceType checks if the service type name of the RegistryError matches the specified name.
 func (r *RegistryError) MatchesServiceType(name string) bool {
 	return r.serviceTypeName == name
 }
-
-// _ ensures that RegistryError implements the ParsleyErrorWithServiceTypeName interface.
-var _ ParsleyErrorWithServiceTypeName = &RegistryError{}
 
 // NewRegistryError creates a new RegistryError with the given message and initializers to modify the error.
 func NewRegistryError(msg string, initializers ...ParsleyErrorFunc) error {

--- a/pkg/types/resolver_error.go
+++ b/pkg/types/resolver_error.go
@@ -1,6 +1,9 @@
 package types
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 const (
 	ErrorServiceTypeNotRegistered               = "service type is not registered"
@@ -55,9 +58,23 @@ type ResolverError struct {
 // _ ensures that the ResolverError implements the ParsleyErrorWithServiceTypeName interface.
 var _ ParsleyErrorWithServiceTypeName = &ResolverError{}
 
-// ServiceTypeName sets the service type name for the ResolverError instance.
-func (r *ResolverError) ServiceTypeName(name string) {
+func (r *ResolverError) setServiceTypeName(name string) {
 	r.serviceTypeName = name
+}
+
+// ServiceTypeName returns the name of the service type associated with the ResolverError instance.
+func (r *ResolverError) ServiceTypeName() string {
+	return r.serviceTypeName
+}
+
+// Error returns the message associated with the ResolverError.
+func (r *ResolverError) Error() string {
+	return r.Msg
+}
+
+// Format implements the fmt.Formatter interface.
+func (r *ResolverError) Format(s fmt.State, verb rune) {
+	formatError(r.Msg, r.serviceTypeName, r.cause, s, verb)
 }
 
 // NewResolverError creates a new ResolverError with the provided message and applies optional ParsleyErrorFunc initializers.
@@ -73,4 +90,9 @@ func NewResolverError(msg string, initializers ...ParsleyErrorFunc) error {
 	}
 
 	return err
+}
+
+// NewResolverErrorForType creates a new ResolverError with the specified message and service type information for type T.
+func NewResolverErrorForType[T any](msg string) error {
+	return NewResolverError(msg, ForServiceType[T]())
 }


### PR DESCRIPTION
### Changes

- Adds `NewResolverErrorForType` for type-safe error creation.
- Refactors `ForServiceType` implementation to use service type information dynamically.
- Enhances error formatting with `fmt.Formatter` for `ResolverError` and `RegistryError`.