### PR TITLE
chore: migrate to cobra-extensions v0.7.0 and cobra-x tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+
+### Changed
+
+* Migrates all command structs to use `types.BaseCommand` and the new `cobra-x` tag format, following breaking changes in `github.com/matzefriedrich/cobra-extensions` v0.7.0. [#89](https://github.com/matzefriedrich/parsley/pull/89)
+* Updates `github.com/matzefriedrich/cobra-extensions` dependency from v0.6.0 to v0.7.0, and removed `//nolint:unused` comments from command structs as they are no longer required with the new `cobra-extensions` version. [#89](https://github.com/matzefriedrich/parsley/pull/89)
+
+
 ## [v1.6.0] - 2026-07-25
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/matzefriedrich/parsley
 go 1.26.4
 
 require (
-	github.com/matzefriedrich/cobra-extensions v0.6.2
+	github.com/matzefriedrich/cobra-extensions v0.7.0
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/matzefriedrich/cobra-extensions v0.6.0 h1:3h43Mm7u+olDmDFZ94ZJ/wCnyX3
 github.com/matzefriedrich/cobra-extensions v0.6.0/go.mod h1:VnrT96yZPT4E/JxzXCLCoYKllq0cmZvmRYSNQAKISRM=
 github.com/matzefriedrich/cobra-extensions v0.6.2 h1:dZqT2ihdx/zp1kR/WOf4dYLWbluSPZ0r5JfCiHO54yk=
 github.com/matzefriedrich/cobra-extensions v0.6.2/go.mod h1:Nrotndw9ManAbqsF/1LMIUHw5eXthyEDYpBzjCQqPgk=
+github.com/matzefriedrich/cobra-extensions v0.7.0 h1:dcenl6raGISUaeVx7JUdgzog+473Y6VI6LT5CnzIR0g=
+github.com/matzefriedrich/cobra-extensions v0.7.0/go.mod h1:Nrotndw9ManAbqsF/1LMIUHw5eXthyEDYpBzjCQqPgk=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/internal/commands/generate_mocks_command.go
+++ b/internal/commands/generate_mocks_command.go
@@ -15,9 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:unused // The use field is used by the cobra-extensions package
 type mocksGeneratorCommand struct {
-	use                 types.CommandName `flag:"mocks" short:"Generate configurable mocks for interface types." long:"Generates fully configurable mock implementations for Go interface types. It simplifies the process of creating mocks by analyzing the source code and automatically generating mock structs that adhere to the defined interfaces."`
+	types.BaseCommand   `cobra-x:"mocks, help='Generate configurable mocks for interface types.', description='Generates fully configurable mock implementations for Go interface types. It simplifies the process of creating mocks by analyzing the source code and automatically generating mock structs that adhere to the defined interfaces.'"`
 	fileAccessor        reflection.AstFileAccessor
 	outputWriterFactory generator.OutputWriterFactory
 }

--- a/internal/commands/generate_proxy_command.go
+++ b/internal/commands/generate_proxy_command.go
@@ -12,9 +12,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:unused // The use field is used by the cobra-extensions package
 type generateProxyCommand struct {
-	use                 types.CommandName `flag:"proxy" short:"Generate generic proxy types for method call interception." long:"Generates generic proxy types designed for method call interception on Go interfaces. These proxies act as intermediaries, allowing you to inject custom behavior—such as logging, validation, or transformation—before or after method execution."`
+	types.BaseCommand   `cobra-x:"proxy, help='Generate generic proxy types for method call interception.', description='Generates generic proxy types designed for method call interception on Go interfaces. These proxies act as intermediaries, allowing you to inject custom behavior—such as logging, validation, or transformation—before or after method execution.'"`
 	fileAccessor        reflection.AstFileAccessor
 	outputWriterFactory generator.OutputWriterFactory
 }

--- a/internal/commands/generator_command.go
+++ b/internal/commands/generator_command.go
@@ -8,9 +8,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:unused // The use field is used by the cobra-extensions package
 type generatorCommand struct {
-	use types.CommandName `flag:"generate" short:"Generate boilerplate code for advanced DI features" long:"A command group providing tools for creating boilerplate code to support advanced dependency injection (DI) features. It serves as a hub for related subcommands, such as generating mocks, proxies, or other utility types, streamlining the setup of DI patterns and improving developer productivity in complex Go projects."`
+	types.BaseCommand `cobra-x:"generate, help='Generate boilerplate code for advanced DI features', description='A command group providing tools for creating boilerplate code to support advanced dependency injection (DI) features. It serves as a hub for related subcommands, such as generating mocks, proxies, or other utility types, streamlining the setup of DI patterns and improving developer productivity in complex Go projects.'"`
 }
 
 func (g *generatorCommand) Execute(_ context.Context) {

--- a/internal/commands/init_command.go
+++ b/internal/commands/init_command.go
@@ -21,9 +21,8 @@ type ScaffoldingFileWriterFactoryFunc func(projectFolder string) (generator.Scaf
 // ProjectLoaderFunc is a function type that loads a Go project given a project folder path.
 type ProjectLoaderFunc func(projectFolderPath string) (generator.GoProject, error)
 
-//nolint:unused // The use field is used by the cobra-extensions package
 type initCommand struct {
-	use                   types.CommandName `flag:"init" short:"Add Parsley to an application" long:"Integrates Parsley into an existing application by setting up the necessary scaffolding for dependency injection and code generation. It initializes project configurations, generates essential files, and prepares the application for using Parsley's advanced features."`
+	types.BaseCommand     `cobra-x:"init, help='Add Parsley to an application', description='Integrates Parsley into an existing application by setting up the necessary scaffolding for dependency injection and code generation. It initializes project configurations, generates essential files, and prepares the application for using advanced features.'"`
 	fileWriterFactoryFunc ScaffoldingFileWriterFactoryFunc
 	projectLoadFunc       ProjectLoaderFunc
 }

--- a/internal/commands/version_command.go
+++ b/internal/commands/version_command.go
@@ -10,11 +10,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:unused // The use field is used by the cobra-extensions package
 type versionCommand struct {
-	use            types.CommandName `flag:"version" short:"Show the current Parsley CLI version"`
-	CheckForUpdate bool              `flag:"check-update" usage:"Checks for available updates and prints the update command"`
-	httpClient     utils.HttpClient
+	types.BaseCommand `cobra-x:"version, help='Show the current Parsley CLI version'"`
+	CheckForUpdate    bool `cobra-x:"-u|--check-update, help='Checks for available updates and prints the update command'"`
+	httpClient        utils.HttpClient
 }
 
 // Execute displays the current Parsley CLI version and checks for updates if enabled. Shows update instructions if a new version exists.


### PR DESCRIPTION
Migrates Parsley CLI to `cobra-extensions` v0.7.0 and the new `cobra-x` struct tags.

### Changes

- Bumps `cobra-extensions` to `v0.7.0`.
- Embeds `types.BaseCommand` in all command structs.
- Migrates metadata and flags to unified `cobra-x` tags.
- Removes obsolete `//nolint:unused` annotations.
- **Affected Commands**: `init`, `version`, `generate`, `mocks`, `proxy`.