### PR TITLE
Add Disposable interface and resolver/scope shutdown support for cleanup of services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-* Introduced `Disposable` interface with a `Dispose(context.Context) error` method to support explicit cleanup of services. [#90](https://github.com/matzefriedrich/parsley/issues/90)
-* Added `Shutdown(context.Context) error` to the `Resolver` interface to facilitate the disposal of singleton services. [#90](https://github.com/matzefriedrich/parsley/issues/90)
-* Added `DisposeScope(context.Context) error` to `pkg/resolving` for disposing of scoped services associated with a context. [#90](https://github.com/matzefriedrich/parsley/issues/90)
-* Added `NewAggregateError` utility to `pkg/types` for grouping multiple disposal errors. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Introduced `Disposable` interface with a `Dispose(context.Context) error` method to support explicit cleanup of services. [#93](https://github.com/matzefriedrich/parsley/pull/93), [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Added `Shutdown(context.Context) error` to the `Resolver` interface to facilitate the disposal of singleton services. [#93](https://github.com/matzefriedrich/parsley/pull/93), [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Added `DisposeScope(context.Context) error` to `pkg/resolving` for disposing of scoped services associated with a context. [#93](https://github.com/matzefriedrich/parsley/pull/93), [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Added `NewAggregateError` utility to `pkg/types` for grouping multiple disposal errors. [#93](https://github.com/matzefriedrich/parsley/pull/93), [#90](https://github.com/matzefriedrich/parsley/issues/90)
 
 ### Changed
  
 * Upgrades Go version to 1.26.5
-* The `bootstrap.RunParsleyApplication` function now automatically handles the disposal of singleton and scoped services upon application exit. [#90](https://github.com/matzefriedrich/parsley/issues/90)
-* Refactored `internal/core.InstanceBag` to track `Disposable` instances and provide thread-safe disposal in reverse order of creation. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* The `bootstrap.RunParsleyApplication` function now automatically handles the disposal of singleton and scoped services upon application exit. [#93](https://github.com/matzefriedrich/parsley/pull/93), [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Refactored `internal/core.InstanceBag` to track `Disposable` instances and provide thread-safe disposal in reverse order of creation. [#93](https://github.com/matzefriedrich/parsley/pull/93), [#90](https://github.com/matzefriedrich/parsley/issues/90)
  
  
 ## [v1.6.1] - 2026-07-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  
 ## [unreleased]
 
+### Added
+
+* Introduced `Disposable` interface with a `Dispose(context.Context) error` method to support explicit cleanup of services. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Added `Shutdown(context.Context) error` to the `Resolver` interface to facilitate the disposal of singleton services. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Added `DisposeScope(context.Context) error` to `pkg/resolving` for disposing of scoped services associated with a context. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Added `NewAggregateError` utility to `pkg/types` for grouping multiple disposal errors. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+
 ### Changed
  
 * Upgrades Go version to 1.26.5
+* The `bootstrap.RunParsleyApplication` function now automatically handles the disposal of singleton and scoped services upon application exit. [#90](https://github.com/matzefriedrich/parsley/issues/90)
+* Refactored `internal/core.InstanceBag` to track `Disposable` instances and provide thread-safe disposal in reverse order of creation. [#90](https://github.com/matzefriedrich/parsley/issues/90)
  
  
 ## [v1.6.1] - 2026-07-30

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 [![CI](https://github.com/matzefriedrich/parsley/actions/workflows/go.yml/badge.svg)](https://github.com/matzefriedrich/parsley/actions/workflows/go.yml)
 [![Coverage Status](https://coveralls.io/repos/github/matzefriedrich/parsley/badge.svg)](https://coveralls.io/github/matzefriedrich/parsley)
 [![Go Reference](https://pkg.go.dev/badge/github.com/matzefriedrich/parsley.svg)](https://pkg.go.dev/github.com/matzefriedrich/parsley)
-[![Go Report Card](https://goreportcard.com/badge/github.com/matzefriedrich/parsley)](https://goreportcard.com/report/github.com/matzefriedrich/parsley)
 ![License](https://img.shields.io/github/license/matzefriedrich/parsley)
 ![GitHub go.mod Go version](https://img.shields.io/github/go-mod/go-version/matzefriedrich/parsley)
 ![GitHub Release](https://img.shields.io/github/v/release/matzefriedrich/parsley?include_prereleases)
@@ -28,6 +27,7 @@ Dependency injection in Go typically relies on constructor functions, which are 
 - **Registration Validation**: Ensures early detection of missing registrations or circular dependencies.
 - **Advanced Registrations**: Register multiple implementations for the same interface using named services or lists.
 - **Proxy and Mock Support**: Generate extensible proxy types and configurable mocks to streamline testing workflows.
+- **Resource Cleanup**: Automatically dispose singleton and scoped service instances implementing `Disposable` during application shutdown.
 
 For a complete overview of features and capabilities, refer to the [Parsley documentation](https://matzefriedrich.github.io/parsley-docs/).
 

--- a/internal/core/instances.go
+++ b/internal/core/instances.go
@@ -2,14 +2,23 @@ package core
 
 import (
 	"context"
+	"maps"
+	"sync"
 
 	"github.com/matzefriedrich/parsley/pkg/types"
 )
 
 type InstanceBag struct {
-	parent    *InstanceBag
-	instances map[uint64]interface{}
-	scope     types.LifetimeScope
+	parent      *InstanceBag
+	instances   map[uint64]any
+	disposables []*disposableRef
+	scope       types.LifetimeScope
+	mu          sync.Mutex
+}
+
+type disposableRef struct {
+	id       uint64
+	disposed bool
 }
 
 type ContextKey string
@@ -21,34 +30,42 @@ const (
 // NewGlobalInstanceBag Creates a new InstanceBag object with global scope.
 func NewGlobalInstanceBag() *InstanceBag {
 	return &InstanceBag{
-		instances: make(map[uint64]interface{}),
-		scope:     types.LifetimeSingleton,
+		instances:   make(map[uint64]any),
+		disposables: make([]*disposableRef, 0),
+		scope:       types.LifetimeSingleton,
 	}
 }
 
 // NewInstancesBag Creates a new InstanceBag object.
 func NewInstancesBag(parent *InstanceBag, scope types.LifetimeScope) *InstanceBag {
 	bag := &InstanceBag{
-		parent:    parent,
-		scope:     scope,
-		instances: make(map[uint64]interface{}),
+		parent:      parent,
+		scope:       scope,
+		instances:   make(map[uint64]any),
+		disposables: make([]*disposableRef, 0),
 	}
-	for k, v := range parent.instances {
-		bag.instances[k] = v
+	if parent != nil {
+		parent.mu.Lock()
+		maps.Copy(bag.instances, parent.instances)
+		parent.mu.Unlock()
 	}
 	return bag
 }
 
 // TryResolveInstance attempts to locate an instance of a service identified by the given registration.
-func (b *InstanceBag) TryResolveInstance(ctx context.Context, registration types.ServiceRegistration) (interface{}, bool) {
+func (b *InstanceBag) TryResolveInstance(ctx context.Context, registration types.ServiceRegistration) (any, bool) {
 	id := registration.Id()
+	b.mu.Lock()
 	instance, found := b.instances[id]
+	b.mu.Unlock()
 	if found {
 		return instance, true
 	}
-	scopedInstances, hasParsleyContext := ctx.Value(ParsleyContext).(map[uint64]interface{})
+	scoped, hasParsleyContext := ctx.Value(ParsleyContext).(*InstanceBag)
 	if hasParsleyContext {
-		instance, found = scopedInstances[id]
+		scoped.mu.Lock()
+		instance, found = scoped.instances[id]
+		scoped.mu.Unlock()
 		if found {
 			return instance, true
 		}
@@ -59,25 +76,57 @@ func (b *InstanceBag) TryResolveInstance(ctx context.Context, registration types
 // KeepInstance stores an instance of a service based on the service's lifetime scope. Singleton instances are stored
 // at the appropriate singleton level in the hierarchy. Scoped instances are stored in the context-specified scope.
 // Transient instances are stored in the current instance bag.
-func (b *InstanceBag) KeepInstance(ctx context.Context, registration types.ServiceRegistration, instance interface{}) {
+func (b *InstanceBag) KeepInstance(ctx context.Context, registration types.ServiceRegistration, instance any) {
 	id := registration.Id()
 	switch registration.LifetimeScope() {
 	case types.LifetimeSingleton:
 		if b.scope == types.LifetimeSingleton {
+			b.mu.Lock()
 			b.instances[id] = instance
+			if _, ok := instance.(types.Disposable); ok {
+				b.disposables = append(b.disposables, &disposableRef{id: id})
+			}
+			b.mu.Unlock()
 		} else {
 			if b.parent != nil {
 				b.parent.KeepInstance(ctx, registration, instance)
 			}
 		}
 	case types.LifetimeScoped:
-		scopedInstances, hasParsleyContext := ctx.Value(ParsleyContext).(map[uint64]interface{})
+		scoped, hasParsleyContext := ctx.Value(ParsleyContext).(*InstanceBag)
 		if hasParsleyContext {
-			scopedInstances[id] = instance
+			scoped.mu.Lock()
+			scoped.instances[id] = instance
+			if _, ok := instance.(types.Disposable); ok {
+				scoped.disposables = append(scoped.disposables, &disposableRef{id: id})
+			}
+			scoped.mu.Unlock()
 		}
 	case types.LifetimeTransient:
 		fallthrough
 	default:
+		b.mu.Lock()
 		b.instances[id] = instance
+		b.mu.Unlock()
 	}
+}
+
+func (b *InstanceBag) Dispose(ctx context.Context) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	var errs []error
+	for i := len(b.disposables) - 1; i >= 0; i-- {
+		ref := b.disposables[i]
+		if disposable, ok := b.instances[ref.id].(types.Disposable); ok {
+			err := disposable.Dispose(ctx)
+			if err != nil {
+				errs = append(errs, err)
+			}
+			ref.disposed = true
+		}
+	}
+	if len(errs) > 0 {
+		return types.NewAggregateError("failed to dispose one or more services", errs)
+	}
+	return nil
 }

--- a/internal/core/instances.go
+++ b/internal/core/instances.go
@@ -117,6 +117,9 @@ func (b *InstanceBag) Dispose(ctx context.Context) error {
 	var errs []error
 	for i := len(b.disposables) - 1; i >= 0; i-- {
 		ref := b.disposables[i]
+		if ref.disposed {
+			continue
+		}
 		if disposable, ok := b.instances[ref.id].(types.Disposable); ok {
 			err := disposable.Dispose(ctx)
 			if err != nil {
@@ -126,7 +129,7 @@ func (b *InstanceBag) Dispose(ctx context.Context) error {
 		}
 	}
 	if len(errs) > 0 {
-		return types.NewAggregateError("failed to dispose one or more services", errs)
+		return types.NewResolverError("failed to dispose one or more services", types.WithAggregatedCause(errs...))
 	}
 	return nil
 }

--- a/internal/tests/bootstrap/disposal_test.go
+++ b/internal/tests/bootstrap/disposal_test.go
@@ -1,0 +1,62 @@
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/bootstrap"
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/matzefriedrich/parsley/pkg/types"
+	"github.com/stretchr/testify/assert"
+)
+
+type singletonService struct {
+	disposed bool
+}
+
+func (s *singletonService) Dispose(ctx context.Context) error {
+	s.disposed = true
+	return nil
+}
+
+type scopedService struct {
+	disposed bool
+}
+
+func (s *scopedService) Dispose(ctx context.Context) error {
+	s.disposed = true
+	return nil
+}
+
+func Test_RunParsleyApplication_disposes_singleton_and_scoped_services(t *testing.T) {
+
+	// Arrange
+	var singleton *singletonService
+	var scoped *scopedService
+
+	appFactory := func(s *singletonService, resolver types.Resolver) bootstrap.Application {
+		singleton = s
+		return &testApp{
+			RunFunc: func(ctx context.Context) error {
+				var err error
+				scoped, err = resolving.ResolveRequiredService[*scopedService](ctx, resolver)
+				return err
+			},
+		}
+	}
+
+	// Act
+	err := bootstrap.RunParsleyApplication(t.Context(), appFactory, func(registry types.ServiceRegistry) error {
+		_ = registration.RegisterSingleton(registry, func() *singletonService { return &singletonService{} })
+		_ = registration.RegisterScoped(registry, func() *scopedService { return &scopedService{} })
+		return nil
+	})
+
+	// Assert
+	assert.NoError(t, err)
+	assert.NotNil(t, singleton)
+	assert.NotNil(t, scoped)
+	assert.True(t, singleton.disposed, "singleton should be disposed")
+	assert.True(t, scoped.disposed, "scoped should be disposed")
+}

--- a/internal/tests/resolving/disposal_test.go
+++ b/internal/tests/resolving/disposal_test.go
@@ -1,0 +1,113 @@
+package resolving
+
+import (
+	"context"
+	"testing"
+
+	"github.com/matzefriedrich/parsley/pkg/registration"
+	"github.com/matzefriedrich/parsley/pkg/resolving"
+	"github.com/stretchr/testify/assert"
+)
+
+type disposableService struct {
+	disposed bool
+}
+
+func (s *disposableService) Dispose(ctx context.Context) error {
+	s.disposed = true
+	return nil
+}
+
+func newDisposableService() *disposableService {
+	return &disposableService{}
+}
+
+func Test_Resolver_Shutdown_disposes_singleton_services(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registration.RegisterSingleton(registry, newDisposableService)
+
+	r := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	service, _ := resolving.ResolveRequiredService[*disposableService](ctx, r)
+
+	// Act
+	err := r.Shutdown(ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, service.disposed)
+}
+
+func Test_DisposeScope_disposes_scoped_services(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registration.RegisterScoped(registry, newDisposableService)
+
+	r := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	service, _ := resolving.ResolveRequiredService[*disposableService](ctx, r)
+
+	// Act
+	err := resolving.DisposeScope(ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.True(t, service.disposed)
+}
+
+func Test_Resolver_Shutdown_does_not_dispose_transient_services(t *testing.T) {
+
+	// Arrange
+	registry := registration.NewServiceRegistry()
+	_ = registration.RegisterTransient(registry, newDisposableService)
+
+	r := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	service, _ := resolving.ResolveRequiredService[*disposableService](ctx, r)
+
+	// Act
+	err := r.Shutdown(ctx)
+
+	// Assert
+	assert.NoError(t, err)
+	assert.False(t, service.disposed)
+}
+
+type orderedDisposableService struct {
+	id      int
+	history *[]int
+}
+
+func (s *orderedDisposableService) Dispose(ctx context.Context) error {
+	*s.history = append(*s.history, s.id)
+	return nil
+}
+
+func Test_Resolver_Shutdown_disposes_in_reverse_order(t *testing.T) {
+
+	// Arrange
+	history := make([]int, 0)
+	registry := registration.NewServiceRegistry()
+	_ = registration.RegisterSingleton(registry, func() *orderedDisposableService {
+		return &orderedDisposableService{id: 1, history: &history}
+	})
+	_ = registration.RegisterSingleton(registry, func() *orderedDisposableService {
+		return &orderedDisposableService{id: 2, history: &history}
+	})
+
+	r := resolving.NewResolver(registry)
+	ctx := resolving.NewScopedContext(t.Context())
+
+	// Act
+	_, _ = resolving.ResolveRequiredServices[*orderedDisposableService](ctx, r)
+	_ = r.Shutdown(ctx)
+
+	// Assert
+	assert.Equal(t, []int{2, 1}, history)
+}

--- a/internal/tests/resolving/disposal_test.go
+++ b/internal/tests/resolving/disposal_test.go
@@ -84,7 +84,7 @@ type orderedDisposableService struct {
 	history *[]int
 }
 
-func (s *orderedDisposableService) Dispose(ctx context.Context) error {
+func (s *orderedDisposableService) Dispose(_ context.Context) error {
 	*s.history = append(*s.history, s.id)
 	return nil
 }

--- a/pkg/bootstrap/application.go
+++ b/pkg/bootstrap/application.go
@@ -42,6 +42,12 @@ func RunParsleyApplication(cxt context.Context, appFactoryFunc any, configure ..
 
 	resolver := resolving.NewResolver(registry)
 	ctx := resolving.NewScopedContext(cxt)
+
+	defer func() {
+		_ = resolver.Shutdown(ctx)
+		_ = resolving.DisposeScope(ctx)
+	}()
+
 	app, appErr := resolving.ResolveRequiredService[Application](ctx, resolver)
 	if appErr != nil {
 		activationErr := &types.ParsleyError{Msg: "failed to activate application"}

--- a/pkg/resolving/resolver.go
+++ b/pkg/resolving/resolver.go
@@ -177,4 +177,8 @@ func (r *resolver) ResolveWithOptions(ctx context.Context, serviceType types.Ser
 	return resolvedInstances, nil
 }
 
+func (r *resolver) Shutdown(ctx context.Context) error {
+	return r.globalInstances.Dispose(ctx)
+}
+
 var _ types.Resolver = &resolver{}

--- a/pkg/resolving/scope.go
+++ b/pkg/resolving/scope.go
@@ -3,10 +3,20 @@ package resolving
 import (
 	"context"
 	"github.com/matzefriedrich/parsley/internal/core"
+	"github.com/matzefriedrich/parsley/pkg/types"
 )
 
 // NewScopedContext creates a new context with an associated service instance map, useful for managing service lifetimes within scope.
 func NewScopedContext(ctx context.Context) context.Context {
-	instances := make(map[uint64]interface{})
-	return context.WithValue(ctx, core.ParsleyContext, instances)
+	bag := core.NewInstancesBag(nil, types.LifetimeScoped)
+	return context.WithValue(ctx, core.ParsleyContext, bag)
+}
+
+// DisposeScope disposes all services in the given context that implement the Disposable interface.
+func DisposeScope(ctx context.Context) error {
+	bag, ok := ctx.Value(core.ParsleyContext).(*core.InstanceBag)
+	if !ok {
+		return nil
+	}
+	return bag.Dispose(ctx)
 }

--- a/pkg/types/parsley_error.go
+++ b/pkg/types/parsley_error.go
@@ -78,14 +78,6 @@ func (f ParsleyAggregateError) Errors() []error {
 	return f.errors
 }
 
-// NewAggregateError creates a new ParsleyAggregateError with the provided message and slice of errors.
-func NewAggregateError(msg string, errs []error) error {
-	return &ParsleyAggregateError{
-		Msg:    msg,
-		errors: errs,
-	}
-}
-
 // Error returns the message associated with the ParsleyAggregateError.
 func (f ParsleyAggregateError) Error() string {
 	return f.Msg

--- a/pkg/types/parsley_error.go
+++ b/pkg/types/parsley_error.go
@@ -78,6 +78,14 @@ func (f ParsleyAggregateError) Errors() []error {
 	return f.errors
 }
 
+// NewAggregateError creates a new ParsleyAggregateError with the provided message and slice of errors.
+func NewAggregateError(msg string, errs []error) error {
+	return &ParsleyAggregateError{
+		Msg:    msg,
+		errors: errs,
+	}
+}
+
 // Error returns the message associated with the ParsleyAggregateError.
 func (f ParsleyAggregateError) Error() string {
 	return f.Msg

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -147,6 +147,11 @@ type NamedService[T any] interface {
 	ActivatorFunc() any
 }
 
+// Disposable represents a service that requires explicit cleanup when it is no longer needed.
+type Disposable interface {
+	Dispose(ctx context.Context) error
+}
+
 // ResolverOptionsFunc represents a function that configures a service registry used by the resolver.
 type ResolverOptionsFunc func(registry ServiceRegistry) error
 
@@ -158,6 +163,9 @@ type Resolver interface {
 
 	// ResolveWithOptions resolves services of the specified type using additional options and returns a list of resolved services or an error.
 	ResolveWithOptions(ctx context.Context, serviceType ServiceType, options ...ResolverOptionsFunc) ([]interface{}, error)
+
+	// Shutdown disposes all registered singleton services that implement the Disposable interface.
+	Shutdown(ctx context.Context) error
 }
 
 // DependencyInfo provides functionality to manage dependency information.


### PR DESCRIPTION
This change introduces explicit resource cleanup support for services managed by Parsley. It adds a new `Disposable` interface, extends the `Resolver` with a `Shutdown` method to dispose singleton service instances, and adds a `DisposeScope` function to `pkg/resolving` to dispose scoped service instances tied to a context.

### Changes

- Added `Disposable` interface with `Dispose(ctx context.Context) error` method, and added `Shutdown(ctx context.Context) error` to the `Resolver` interface.
- Implemented `Shutdown` method on the resolver to dispose all tracked singleton instances.
- Added `DisposeScope(ctx context.Context) error` to dispose scoped service instances associated with a given context.
- Refactored `InstanceBag` to track `Disposable` instances (in creation order) and dispose them in reverse creation order, with thread-safe locking to guard concurrent access.
- `RunParsleyApplication` now defers both resolver shutdown (for singleton disposal) and scope disposal (for scoped disposal) to ensure cleanup happens automatically at the end of the application lifecycle.
